### PR TITLE
Fix create account and log in links in AuthIdentity

### DIFF
--- a/src/components/Auth/AuthIdentity.js
+++ b/src/components/Auth/AuthIdentity.js
@@ -153,6 +153,7 @@ const AuthIdentity = () => {
                 title="Create Account →"
                 type="link"
                 size="micro"
+                onClick={() => dispatch(updateAuth({ type: 'signup' }))}
               />
             </span>
           </SmallSystemText>
@@ -168,6 +169,7 @@ const AuthIdentity = () => {
                 title="Log in →"
                 type="link"
                 size="micro"
+                onClick={() => dispatch(updateAuth({ type: 'login' }))}
               />
             </span>
           </SmallSystemText>

--- a/src/components/Auth/AuthIdentity.js
+++ b/src/components/Auth/AuthIdentity.js
@@ -24,6 +24,7 @@ const AuthIdentity = () => {
         userExists,
         userProfile,
         step: nextStep,
+        prevStep: state.step,
       })
     );
   };

--- a/src/components/Auth/AuthLayout/AuthLayout.js
+++ b/src/components/Auth/AuthLayout/AuthLayout.js
@@ -1,11 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Box, Card } from '../../../ui-kit';
+import { Box, Card, Button } from '../../../ui-kit';
 import customizations from './customizations';
 import { Heading, SubHeading } from './AuthLayout.styles';
+import { update as updateAuth, useAuth } from '../../../providers/AuthProvider';
+import authSteps from '../authSteps';
 
 function AuthLayout(props = {}) {
+  const [state, dispatch] = useAuth();
+
+  const onGoBack = () => {
+    dispatch(
+      updateAuth({
+        step: state.prevStep,
+        prevStep: authSteps.Welcome,
+      })
+    );
+  };
+
   return (
     <Box
       position="fixed"
@@ -22,11 +35,20 @@ function AuthLayout(props = {}) {
     >
       <Card
         p="l"
+        pt="base"
         display="flex"
         flexDirection="column"
         width="440px"
         {...props}
       >
+        {state.prevStep === authSteps.Identity ? (
+          <Button
+            type="link"
+            title="< Back"
+            onClick={() => onGoBack()}
+            alignSelf="flex-end"
+          />
+        ) : null}
         <Heading>{props.heading || customizations.defaulthHeading}</Heading>
         <SubHeading>
           {props.subHeading || customizations.defaultSubHeading}

--- a/src/components/Auth/AuthLayout/AuthLayout.js
+++ b/src/components/Auth/AuthLayout/AuthLayout.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { CaretLeft } from 'phosphor-react';
 
 import { Box, Card, Button } from '../../../ui-kit';
 import customizations from './customizations';
@@ -44,9 +45,13 @@ function AuthLayout(props = {}) {
         {state.prevStep === authSteps.Identity ? (
           <Button
             type="link"
-            title="< Back"
+            title="Back"
             onClick={() => onGoBack()}
             alignSelf="flex-end"
+            color="text.action"
+            alignItems="center"
+            display="flex"
+            icon={<CaretLeft />}
           />
         ) : null}
         <Heading>{props.heading || customizations.defaulthHeading}</Heading>


### PR DESCRIPTION
Quick fix to toggle between login and sign-up screens. Also, added a back button to the confirm screen just in case a user puts in the wrong email.

![2023-03-20 13 59 38](https://user-images.githubusercontent.com/2528817/226439832-decdcb8d-418c-46b7-bd48-34c31c657610.gif)
![2023-03-20 15 07 27](https://user-images.githubusercontent.com/2528817/226453888-c2d00695-9678-4b43-9576-e969fa9a0106.gif)
