### PR TITLE
⭐️ Make Content Cards more consistent in size

### DIFF
--- a/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { getURLFromType } from '../../../utils';
 import { ContentCard, Box, H3, systemPropTypes, Button } from '../../../ui-kit';
@@ -17,12 +17,12 @@ const responsive = {
     partialVisibilityGutter: 30,
   },
   tablet: {
-    breakpoint: { max: 1024, min: 464 },
+    breakpoint: { max: 1024, min: 600 },
     items: 2,
     partialVisibilityGutter: 30,
   },
   mobile: {
-    breakpoint: { max: 464, min: 0 },
+    breakpoint: { max: 600, min: 0 },
     items: 1,
     partialVisibilityGutter: 30,
   },

--- a/src/components/FeatureFeed/Features/VerticalCardListFeature.js
+++ b/src/components/FeatureFeed/Features/VerticalCardListFeature.js
@@ -1,14 +1,14 @@
-import React from "react";
-import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
 
-import { getURLFromType } from "../../../utils";
-import { ContentCard, Box, H3, systemPropTypes, Button } from "../../../ui-kit";
+import { getURLFromType } from '../../../utils';
+import { ContentCard, Box, H3, systemPropTypes, Button } from '../../../ui-kit';
 import {
   add as addBreadcrumb,
   useBreadcrumb,
-} from "../../../providers/BreadcrumbProvider";
+} from '../../../providers/BreadcrumbProvider';
 
-import VerticalCardList from "./VerticalCardListFeature.styles";
+import VerticalCardList from './VerticalCardListFeature.styles';
 
 function VerticalCardListFeature(props = {}) {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/src/components/FeatureFeed/Features/VerticalCardListFeature.styles.js
+++ b/src/components/FeatureFeed/Features/VerticalCardListFeature.styles.js
@@ -1,11 +1,6 @@
-import styled from "styled-components";
-import { space } from "styled-system";
-import Carousel from "react-multi-carousel";
-import "react-multi-carousel/lib/styles.css";
-import { withTheme } from "styled-components";
-import { themeGet } from "@styled-system/theme-get";
-
-import { TypeStyles } from "../../../ui-kit/Typography";
+import styled from 'styled-components';
+import 'react-multi-carousel/lib/styles.css';
+import { themeGet } from '@styled-system/theme-get';
 
 const VerticalListContainer = styled.div`
   display: grid;
@@ -14,10 +9,10 @@ const VerticalListContainer = styled.div`
   grid-auto-rows: 1fr;
   grid-auto-columns: 1fr;
   grid-gap: 20px;
-  @media screen and (max-width: ${themeGet("breakpoints.lg")}) {
+  @media screen and (max-width: ${themeGet('breakpoints.lg')}) {
     grid-template-columns: repeat(2, 1fr);
   }
-  @media screen and (max-width: ${themeGet("breakpoints.md")}) {
+  @media screen and (max-width: ${themeGet('breakpoints.md')}) {
     grid-template-columns: repeat(1, 1fr);
   }
 `;

--- a/src/components/FeatureFeedList/FeatureFeedListGrid.js
+++ b/src/components/FeatureFeedList/FeatureFeedListGrid.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { withTheme } from 'styled-components';
 
 import { getURLFromType } from '../../utils';
@@ -28,7 +28,15 @@ function FeatureFeedListGrid(props = {}) {
 
   return (
     <Box pb="l" {...props}>
-      <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gridGap="20px">
+      <Box
+        display="grid"
+        gridGap="20px"
+        gridTemplateColumns={{
+          _: 'repeat(1, 1fr)',
+          md: 'repeat(2, 1fr)',
+          lg: 'repeat(3, 1fr)',
+        }}
+      >
         {props.data.features[0]?.cards?.map((item, index) => (
           <ContentCard
             key={item.title}

--- a/src/ui-kit/ContentCard/ContentCard.js
+++ b/src/ui-kit/ContentCard/ContentCard.js
@@ -1,25 +1,17 @@
-import React from "react";
-import { withTheme } from "styled-components";
-import isNil from "lodash/isNil";
-import { Check } from "phosphor-react";
+import React from 'react';
+import { withTheme } from 'styled-components';
+import { Check } from 'phosphor-react';
 
 import {
-  BodyText,
   SmallBodyText,
   Box,
   H4,
   systemPropTypes,
   ProgressBar,
-} from "../../ui-kit";
-import { useVideoMediaProgress } from "../../hooks";
-import { getPercentWatched } from "../../utils";
-import {
-  Title,
-  Image,
-  BottomSlot,
-  CompleteIndicator,
-  Ellipsis,
-} from "./ContentCard.styles";
+} from '../../ui-kit';
+import { useVideoMediaProgress } from '../../hooks';
+import { getPercentWatched } from '../../utils';
+import { BottomSlot, CompleteIndicator, Ellipsis } from './ContentCard.styles';
 
 function ContentCard(props = {}) {
   const { userProgress, loading: videoProgressLoading } = useVideoMediaProgress(
@@ -37,17 +29,17 @@ function ContentCard(props = {}) {
   return (
     <Box
       flex={1}
-      m={"0 10px"}
-      cursor={props.onClick ? "pointer" : "default"}
+      m={'0 10px'}
+      cursor={props.onClick ? 'pointer' : 'default'}
       borderRadius="xl"
       overflow="hidden"
       backgroundColor="neutral.gray6"
       boxShadow="medium"
       height="100%"
-      display={props.horizontal ? "flex" : ""}
+      display={props.horizontal ? 'flex' : ''}
       {...props}
     >
-      <Box position="relative" width={props.horizontal ? "50%" : ""}>
+      <Box position="relative" width={props.horizontal ? '50%' : ''}>
         {/* Image */}
         <Box
           backgroundSize="cover"
@@ -74,11 +66,15 @@ function ContentCard(props = {}) {
         padding="base"
         background="material.regular"
         backdrop-filter="blur(64px)"
-        width={props.horizontal ? "50%" : ""}
+        width={props.horizontal ? '50%' : ''}
       >
         <SmallBodyText color="text.secondary">{props.subtitle}</SmallBodyText>
-        <H4>{props.title}</H4>
-        <SmallBodyText color="text.secondary">{props.summary}</SmallBodyText>
+        <H4>
+          <Ellipsis>{props.title}</Ellipsis>
+        </H4>
+        <SmallBodyText color="text.secondary">
+          <Ellipsis>{props.summary}</Ellipsis>
+        </SmallBodyText>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Basecamp Scope

[⭐️ Make Content Cards more consistent in size](https://3.basecamp.com/3926363/buckets/27088350/todos/5978155783)

## What was done?
1. Refactor horizontal list and feature feed grid to be more responsive
2. Refactor content card to use ellipses to truncate text after one line in order to keep card heights more consistent (this can be reverted if it doesn't fit the intended design)

Before:

https://user-images.githubusercontent.com/68402088/228653224-4faff404-5317-4495-a211-0d57b08e8306.mov

After:

https://user-images.githubusercontent.com/68402088/228652948-fb142b2d-7fa6-46a3-9778-a3a2ef4501b1.mov

