### PR TITLE
⭐️ Add logic to Continue watching section

### DIFF
--- a/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -67,27 +67,48 @@ function HorizontalCardListFeature(props = {}) {
           />
         ) : null}
       </Box>
-      <Carousel
-        swipeable={true}
-        draggable={false}
-        showDots={false}
-        responsive={responsive}
-        ssr={true} // means to render carousel on server-side.
-        infinite={true}
-        autoPlaySpeed={1000}
-        keyBoardControl={true}
-      >
-        {props.feature?.cards?.map((item, index) => (
-          <ContentCard
-            key={item.title}
-            image={item.coverImage}
-            title={item.title}
-            summary={item.summary}
-            onClick={() => handleActionPress(item)}
-            videoMedia={item.relatedNode?.videos[0]}
-          />
-        ))}
-      </Carousel>
+      {props?.feature?.cards?.length >= 1 ? (
+        <Carousel
+          swipeable={true}
+          draggable={false}
+          showDots={false}
+          responsive={responsive}
+          ssr={true} // means to render carousel on server-side.
+          infinite={true}
+          autoPlaySpeed={1000}
+          keyBoardControl={true}
+        >
+          {props.feature?.cards?.map((item, index) => (
+            <ContentCard
+              key={item.title}
+              image={item.coverImage}
+              title={item.title}
+              summary={item.summary}
+              onClick={() => handleActionPress(item)}
+              videoMedia={item.relatedNode?.videos[0]}
+            />
+          ))}
+        </Carousel>
+      ) : (
+        <Box
+          width="100%"
+          display="flex"
+          justifyContent="center"
+          pt="l"
+          px="l"
+          textAlign="center"
+        >
+          {props.feature.title === 'Continue Watching' ? (
+            <Box fontSize="16px" fontWeight="600" color="base.primary">
+              All caught up? Check out our other sections for more options.
+            </Box>
+          ) : (
+            <Box fontStyle="italic" fontSize="14px">
+              Sorry, there is no media available at this time.
+            </Box>
+          )}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -53,6 +53,13 @@ function HorizontalCardListFeature(props = {}) {
     );
   };
 
+  if (
+    props.feature.title === 'Continue Watching' &&
+    props?.feature?.cards?.length < 1
+  ) {
+    return <></>;
+  }
+
   return (
     <Box pb="l" {...props}>
       <Box display="flex">

--- a/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/src/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -100,7 +100,7 @@ function HorizontalCardListFeature(props = {}) {
         >
           {props.feature.title === 'Continue Watching' ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
-              All caught up? Check out our other sections for more options.
+              All caught up? Check out our other sections for more content!
             </Box>
           ) : (
             <Box fontStyle="italic" fontSize="14px">


### PR DESCRIPTION
## Basecamp Scope

[⭐️ Add logic to Continue watching section](https://3.basecamp.com/3926363/buckets/27088350/todos/5978180888)

Note: This is open to input on design & necessity 

## What was done?

1. Added logic for displaying "no content" messages
<img width="956" alt="image" src="https://user-images.githubusercontent.com/68402088/228671722-dea02bc5-0174-42b4-9634-5a8bdce51a6b.png">

<img width="930" alt="image" src="https://user-images.githubusercontent.com/68402088/228907212-999bc72a-84cf-41c8-a691-43008068ff3d.png">

