### PR TITLE
⭐️ Limit height of content in HeroCardList

### DIFF
--- a/src/components/FeatureFeed/Features/HeroListFeature.js
+++ b/src/components/FeatureFeed/Features/HeroListFeature.js
@@ -58,10 +58,6 @@ function HeroListFeature(props = {}) {
             height="100%"
           />
         </Box>
-
-        {/* {props.feature.heroCard.coverImage?.sources[0]?.uri} */}
-        {/* {'https://wallpaperaccess.com/full/2427256.jpg'} */}
-
         {/* Masthead */}
         <Box
           padding="base"

--- a/src/components/FeatureFeed/Features/HeroListFeature.js
+++ b/src/components/FeatureFeed/Features/HeroListFeature.js
@@ -33,7 +33,7 @@ function HeroListFeature(props = {}) {
   };
 
   return (
-    <Box mb="base" {...props}>
+    <Box mb="base" minWidth="180px" {...props}>
       {/* Content */}
       <Box
         position="relative"
@@ -42,10 +42,26 @@ function HeroListFeature(props = {}) {
         overflow="hidden"
       >
         {/* Image */}
-        <img
-          src={props.feature.heroCard.coverImage?.sources[0]?.uri}
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          backgroundColor="white"
           width="100%"
-        />
+          maxHeight="700px"
+          overflow="hidden"
+        >
+          <Box
+            as="img"
+            src={props.feature.heroCard.coverImage?.sources[0]?.uri}
+            width="100%"
+            height="100%"
+          />
+        </Box>
+
+        {/* {props.feature.heroCard.coverImage?.sources[0]?.uri} */}
+        {/* {'https://wallpaperaccess.com/full/2427256.jpg'} */}
+
         {/* Masthead */}
         <Box
           padding="base"
@@ -59,10 +75,24 @@ function HeroListFeature(props = {}) {
           <Box
             display="flex"
             alignSelf="flex-start"
-            flexDirection="row"
+            flexDirection={{
+              _: 'column',
+              md: 'row',
+            }}
             mt="base"
           >
-            <Button mr="base" title="Watch now" onClick={handleWatchNowPress} />
+            <Button
+              mr={{
+                _: '0',
+                md: 'base',
+              }}
+              mb={{
+                _: 'base',
+                md: '0',
+              }}
+              title="Watch now"
+              onClick={handleWatchNowPress}
+            />
             {props.feature.primaryAction ? (
               <Button
                 title={props.feature.primaryAction.title}
@@ -72,7 +102,6 @@ function HeroListFeature(props = {}) {
             ) : null}
           </Box>
         </Box>
-
         {/* Actions / Cards list */}
         {props.feature.actions?.length ? (
           <Box>


### PR DESCRIPTION
## Basecamp Scope

[⭐️ Limit height of content in HeroCardList](https://3.basecamp.com/3926363/buckets/27088350/todos/5978159937)

## What was done?

1. Add a maximum height to the image used in hero
2. will center the image in cases where images are larger than maximum height (similar to content cards)
3. buttons will flex to column on smaller resolution  in order to prevent cutoff

Before:

https://user-images.githubusercontent.com/68402088/228948567-9bfa0c64-7061-4396-8e1e-8efaa3e1b69f.mov

After:

https://user-images.githubusercontent.com/68402088/228948558-746ab60d-46a8-4d88-a5bd-b3f8dc0baa02.mov

