### PR TITLE
🧹 Clean up login input styling

### DIFF
--- a/src/ui-kit/Input/Input.styles.js
+++ b/src/ui-kit/Input/Input.styles.js
@@ -54,7 +54,7 @@ const textInputStateStyle = ({ theme, error }) => {
 
 const Input = withTheme(styled.input`
   ${TypeStyles.LargeSystemText}
-  padding: ${themeGet('space.xs')} 0;
+  padding: ${themeGet('space.s')} 0 ${themeGet('space.xxs')} 0;
   transition: all ${themeGet('timing.xl')} ease-out;
   placeholder-text-color: ${({ theme }) =>
     Color(theme.colors.text.secondary).alpha(0)};


### PR DESCRIPTION
[🧹 Clean up login styling](https://3.basecamp.com/3926363/buckets/27088350/todos/5999023276)

What was done:
 - Changed padding


Before:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/68402088/228951084-78f81c0e-0e1f-460a-867b-fe88481d6e5f.png">

After:
<img width="489" alt="image" src="https://user-images.githubusercontent.com/68402088/228951007-efc9ce8d-083f-423c-ae1d-892fffc6e739.png">