### PR TITLE
Add campus Id to feature feed

### DIFF
--- a/src/embeds/FeatureFeed.js
+++ b/src/embeds/FeatureFeed.js
@@ -14,11 +14,12 @@ import {
   LivestreamSingle,
 } from '../components';
 import { Box } from '../ui-kit';
+import { useCurrentUser } from '../hooks';
 import { useSearchParams, useLocation } from 'react-router-dom';
 
 function RenderFeatures(props) {
   const [searchParams] = useSearchParams();
-
+  const { currentUser } = useCurrentUser();
   const _id = searchParams.get('id');
 
   const [type, randomId] = _id?.split(/-(.*)/s) ?? [];
@@ -73,6 +74,7 @@ function RenderFeatures(props) {
             Component={Feed}
             options={{
               variables: {
+                campusId: currentUser?.campus?.id,
                 tab: 'TV',
               },
             }}

--- a/src/hooks/useCurrentUser.js
+++ b/src/hooks/useCurrentUser.js
@@ -26,7 +26,11 @@ export const GET_CURRENT_USER = gql`
 `;
 
 function useCurrentUser(options = {}) {
-  const query = useAuthQuery(GET_CURRENT_USER, options);
+  const query = useAuthQuery(GET_CURRENT_USER, {
+    fetchPolicy: 'cache-and-network',
+    errorPolicy: 'all',
+    ...options,
+  });
 
   return {
     currentUser: query?.data?.currentUser || null,

--- a/src/hooks/useTabFeed.js
+++ b/src/hooks/useTabFeed.js
@@ -4,8 +4,8 @@ import { VIDEO_MEDIA_FIELDS } from '../fragments';
 export const TAB_FEED_FEATURES = gql`
   ${VIDEO_MEDIA_FIELDS}
 
-  query tabFeed($tab: Tab!) {
-    tabFeedFeatures(tab: $tab) {
+  query tabFeed($campusId: ID, $tab: Tab!) {
+    tabFeedFeatures(campusId: $campusId, tab: $tab) {
       id
       features {
         id

--- a/src/providers/TabFeedProvider.js
+++ b/src/providers/TabFeedProvider.js
@@ -32,6 +32,7 @@ TabFeedProvider.propTypes = {
   ]).isRequired,
   options: PropTypes.shape({
     variables: PropTypes.shape({
+      campusId: PropTypes.string,
       tab: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,


### PR DESCRIPTION
Add campus Id to feature feed to see 'At your campus' section in the feed.

To Test:
Login into embeds with 'bayside' as the church. You can change the church in the `index.html` file on both places you see `data-church`


<img width="758" alt="CleanShot 2023-04-03 at 16 02 24@2x" src="https://user-images.githubusercontent.com/2528817/229626916-5d6ffa29-d6a1-41fa-a66b-e48c48d7fb05.png">


<img width="905" alt="image" src="https://user-images.githubusercontent.com/2528817/229626584-5fb997ad-4741-4fc8-acbf-9a4d1e098d3b.png">
