### PR TITLE
Return a status from the useLivestreamStatus hook

### DIFF
--- a/src/components/FeatureFeed/Feed.js
+++ b/src/components/FeatureFeed/Feed.js
@@ -52,7 +52,7 @@ const Feed = (props) => {
     );
   }
 
-  const features = props.data?.features.filter(
+  const features = props?.data?.features?.filter(
     (feature) => feature.cards !== null
   );
   const renderedFeatures = features?.map(renderFeature).filter(isNil);

--- a/src/components/LivestreamSingle.js
+++ b/src/components/LivestreamSingle.js
@@ -23,7 +23,7 @@ import {
   Longform,
   ShareButton,
 } from '../ui-kit';
-import { useVideoMediaProgress, useLivestreamIsActive } from '../hooks';
+import { useVideoMediaProgress, useLivestreamStatus } from '../hooks';
 import VideoPlayer from './VideoPlayer';
 
 const MAX_EPISODE_COUNT = 20;
@@ -32,7 +32,7 @@ function LivestreamSingle(props = {}) {
   const navigate = useNavigate();
 
   const invalidPage = !props.loading && !props.data;
-  const isLive = useLivestreamIsActive(props?.data);
+  const { status } = useLivestreamStatus(props?.data);
 
   // Video details
   const videoMedia = props.data?.stream?.sources?.uri;
@@ -135,7 +135,9 @@ function LivestreamSingle(props = {}) {
             mb="s"
           >
             <Box>
-              {isLive ? <LiveChip display="inline-block" /> : null}
+              {status ? (
+                <LiveChip display="inline-block" status={status} />
+              ) : null}
               {/* Title */}
               {title && !hasChildContent ? <H2>{title}</H2> : null}
               {title && hasChildContent ? <H1>{title}</H1> : null}

--- a/src/components/VideoPlayer/VideoPlayer.js
+++ b/src/components/VideoPlayer/VideoPlayer.js
@@ -4,7 +4,7 @@ import DOMPurify from 'dompurify';
 
 import { round } from 'lodash';
 
-import { useInteractWithNode, useLivestreamIsActive } from '../../hooks';
+import { useInteractWithNode, useLivestreamStatus } from '../../hooks';
 import { Box } from '../../ui-kit';
 
 import { videoFilters } from '../../utils';
@@ -24,7 +24,8 @@ function VideoPlayer(props = {}) {
   const previouslyReportedPlayhead = useRef(0);
   const [_interactWithNode] = useInteractWithNode();
 
-  const isLiveStreaming = useLivestreamIsActive(props.parentNode);
+  const { status } = useLivestreamStatus(props.parentNode);
+  const isLiveStreaming = status === 'isLive';
 
   // Player state
   const playerRef = useRef(null);

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,7 +6,7 @@ import useCurrentUser from './useCurrentUser';
 import useFeatureFeed from './useFeatureFeed';
 import useForm from './useForm';
 import useInteractWithNode from './useInteractWithNode';
-import useLivestreamIsActive from './useLivestreamIsActive';
+import useLivestreamStatus from './useLivestreamStatus';
 import useRequestLogin from './useRequestLogin';
 import useRequestRegister from './useRequestRegister';
 import useTabFeed from './useTabFeed';
@@ -24,7 +24,7 @@ export {
   useFeatureFeed,
   useForm,
   useInteractWithNode,
-  useLivestreamIsActive,
+  useLivestreamStatus,
   useRequestLogin,
   useRequestRegister,
   useTabFeed,

--- a/src/hooks/useLivestreamStatus.js
+++ b/src/hooks/useLivestreamStatus.js
@@ -1,11 +1,3 @@
-/**
- * useLivestreamIsActive.js
- *
- * Hook that will manage the timers and report on the status of a Livestream.
- *
- * note : this hook will note fetch the livestream data
- */
-
 import { useState, useEffect } from 'react';
 import {
   isWithinInterval,
@@ -16,11 +8,12 @@ import {
   isValid,
 } from 'date-fns';
 
-const useLivestreamIsActive = (livestream) => {
+const useLivestreamStatus = (livestream) => {
   const id = livestream?.id;
   const start = livestream?.start;
   const durationInSeconds = livestream?.durationInSeconds;
   const [isLive, setIsLive] = useState(false);
+  const [comingUp, setComingUp] = useState(false);
 
   useEffect(() => {
     if (!start || !durationInSeconds) {
@@ -50,8 +43,10 @@ const useLivestreamIsActive = (livestream) => {
 
     // The current time is before the Live Stream STARTS, so we need to trigger the state to enable the label when it's live
     if (isBefore(now, liveStreamStart)) {
+      setComingUp(true);
       timeouts.push(
         setTimeout(() => {
+          setComingUp(false);
           setIsLive(true);
         }, differenceInMilliseconds(liveStreamStart, now))
       );
@@ -71,7 +66,7 @@ const useLivestreamIsActive = (livestream) => {
     };
   }, [start, durationInSeconds, id]);
 
-  return isLive;
+  return { status: isLive ? 'isLive' : comingUp ? 'comingUp' : null };
 };
 
-export default useLivestreamIsActive;
+export default useLivestreamStatus;

--- a/src/ui-kit/MediaItem/LiveChip.js
+++ b/src/ui-kit/MediaItem/LiveChip.js
@@ -15,7 +15,7 @@ const LiveChip = (props) => {
   return (
     <LiveChipContainer {...props}>
       <SmallSystemText fontWeight="700" color="white">
-        LIVE
+        {props.status === 'isLive' ? 'LIVE' : 'COMING UP'}
       </SmallSystemText>
     </LiveChipContainer>
   );

--- a/src/ui-kit/MediaItem/MediaItem.js
+++ b/src/ui-kit/MediaItem/MediaItem.js
@@ -22,7 +22,7 @@ import {
   Ellipsis,
 } from './MediaItem.styles';
 import LiveChip from './LiveChip';
-import { useLivestreamIsActive } from '../../hooks';
+import { useLivestreamStatus } from '../../hooks';
 function MediaItem(props = {}) {
   const { userProgress, loading: videoProgressLoading } = useVideoMediaProgress(
     {
@@ -36,7 +36,7 @@ function MediaItem(props = {}) {
     userProgress,
   });
 
-  const isLive = useLivestreamIsActive(props.relatedNode);
+  const { status } = useLivestreamStatus(props.relatedNode);
 
   return (
     <Box
@@ -62,9 +62,9 @@ function MediaItem(props = {}) {
           overflow="hidden"
           paddingBottom="56.25%"
         />
-        {isLive ? (
+        {status ? (
           <Box position="absolute" top={unit(4)} left={unit(4)} zIndex={1}>
-            <LiveChip />
+            <LiveChip status={status} />
           </Box>
         ) : null}
         {/* Progress / Completed Indicators */}

--- a/src/ui-kit/MediaItem/MediaItem.styles.js
+++ b/src/ui-kit/MediaItem/MediaItem.styles.js
@@ -38,9 +38,22 @@ export const Ellipsis = withTheme(styled.div`
 `);
 
 // :: Chip
+
+const chipBackground = ({ status }) => {
+  if (status) {
+    return css`
+      background-color: ${status === 'isLive'
+        ? themeGet('colors.base.live')
+        : themeGet('colors.neutral.gray2')};
+    `;
+  }
+  return null;
+};
+
 export const LiveChipContainer = withTheme(styled.div`
-  background-color: ${themeGet('colors.base.live')};
   border-radius: ${unit(1)};
   padding: ${unit(1)} ${unit(3)};
+  ${chipBackground}
+
   ${system}
 `);


### PR DESCRIPTION
Updates the `useLivestreamIsActive` hook to be `useLivestreamStatus` and return a status of `isLive` or `comingUp`. This makes it so we can have more granular control with what styles and information we show on the `LiveChip` component. In the future we will probably add actual time until the stream is live. I felt this is a good iterative step towards that functionality.

<img width="973" alt="image" src="https://user-images.githubusercontent.com/2528817/230440887-8f4cbeb2-3a6f-49bb-adfc-44f603a64370.png">
