### PR TITLE
🛠 Breadcrumbs not working correctly when navigating backwards in the browser 

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -5,6 +5,7 @@ import { Box, Button, SystemText } from '../../ui-kit';
 import {
   remove as removeBreadcrumb,
   add as addBreadcrumb,
+  reset as resetBreadcrumb,
   useBreadcrumb,
 } from '../../providers/BreadcrumbProvider';
 
@@ -12,51 +13,13 @@ function Breadcrumbs(props = {}) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [state, dispatch] = useBreadcrumb();
-  const prevIdxRef = useRef(null);
-  const prevStateRef = useRef(null);
-  const currentIdx = window.history.state ? window.history.state.idx : null;
   const currentState = state[state.length - 1];
 
   useEffect(() => {
     const handleHistoryChange = () => {
-      //If they refreshed the page,
-      console.log('INITIAL');
-      // console.log('prevStateRef', prevStateRef.current);
-      console.log('currentState', currentState);
-      // console.log('prevIdxRef', prevIdxRef.current);
-      // console.log('currentIdx', currentIdx);
       if (currentState) {
-        if (currentState) {
-          // prevStateRef.current = currentState;
-          dispatch(removeBreadcrumb(currentState.id));
-          console.log('Removing... prevStateRef set and dispatched');
-        }
-        // else {
-        //   dispatch(
-        //     addBreadcrumb({
-        //       url: prevStateRef.current.url,
-        //       title: prevStateRef.current.title,
-        //     })
-        //   );
-        //   prevStateRef.current = null;
-        //   console.log('Adding... prevStateRef removed and dispatched');
-        // }
+        dispatch(removeBreadcrumb(currentState.id));
       }
-
-      // if (prevIdxRef.current > currentIdx) {
-      //   console.log('BACK');
-      //   // console.log('prevStateRef', prevStateRef.current);
-      //   // console.log('currentState', currentState);
-      //   console.log('prevIdxRef', prevIdxRef.current);
-      //   console.log('currentIdx', currentIdx);
-      //   // Do something when user clicks back button
-      // } else {
-      //   console.log('NOTHING');
-      //   // console.log('prevStateRef', prevStateRef.current);
-      //   // console.log('currentState', currentState);
-      //   console.log('prevIdxRef', prevIdxRef.current);
-      //   console.log('currentIdx', currentIdx);
-      // }
     };
 
     window.addEventListener('popstate', handleHistoryChange);

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -6,6 +6,7 @@ import {
   remove as removeBreadcrumb,
   add as addBreadcrumb,
   reset as resetBreadcrumb,
+  set as setBreadcrumb,
   useBreadcrumb,
 } from '../../providers/BreadcrumbProvider';
 
@@ -13,14 +14,26 @@ function Breadcrumbs(props = {}) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [state, dispatch] = useBreadcrumb();
+  const prevStateRef = useRef(state);
   const currentState = state[state.length - 1];
 
   useEffect(() => {
+    console.log('prevStateRef useEffect', prevStateRef.current);
+    console.log('state useEffect', state);
     const handleHistoryChange = () => {
+      // console.log('prevStateRef popstate', prevStateRef.current);
+      // console.log('state popstate', state);
       if (currentState) {
-        dispatch(removeBreadcrumb(currentState.id));
+        // prevStateRef.current = prevStateRef.current.pop();
+        dispatch(setBreadcrumb(prevStateRef.current.slice(0, -1)));
       }
+      // if (prevStateRef.current === state) {
+      //   console.log('FORWARD');
+      // }
     };
+    console.log('prevStateRef Before update:', prevStateRef.current);
+    prevStateRef.current = state;
+    console.log('prevStateRef After update:', prevStateRef.current);
 
     window.addEventListener('popstate', handleHistoryChange);
     return () => {

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { CaretRight } from 'phosphor-react';
 import { Box, Button, SystemText } from '../../ui-kit';
 import {
   remove as removeBreadcrumb,
+  add as addBreadcrumb,
   useBreadcrumb,
 } from '../../providers/BreadcrumbProvider';
 
@@ -11,13 +12,64 @@ function Breadcrumbs(props = {}) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [state, dispatch] = useBreadcrumb();
-  // const [viewWidth, setViewWidth] = React.useState(0);
-  // const boxWidth = viewWidth * 0.25 - 66;
+  const prevIdxRef = useRef(null);
+  const prevStateRef = useRef(null);
+  const currentIdx = window.history.state ? window.history.state.idx : null;
+  const currentState = state[state.length - 1];
+
+  useEffect(() => {
+    const handleHistoryChange = () => {
+      //If they refreshed the page,
+      console.log('INITIAL');
+      // console.log('prevStateRef', prevStateRef.current);
+      console.log('currentState', currentState);
+      // console.log('prevIdxRef', prevIdxRef.current);
+      // console.log('currentIdx', currentIdx);
+      if (currentState) {
+        if (currentState) {
+          // prevStateRef.current = currentState;
+          dispatch(removeBreadcrumb(currentState.id));
+          console.log('Removing... prevStateRef set and dispatched');
+        }
+        // else {
+        //   dispatch(
+        //     addBreadcrumb({
+        //       url: prevStateRef.current.url,
+        //       title: prevStateRef.current.title,
+        //     })
+        //   );
+        //   prevStateRef.current = null;
+        //   console.log('Adding... prevStateRef removed and dispatched');
+        // }
+      }
+
+      // if (prevIdxRef.current > currentIdx) {
+      //   console.log('BACK');
+      //   // console.log('prevStateRef', prevStateRef.current);
+      //   // console.log('currentState', currentState);
+      //   console.log('prevIdxRef', prevIdxRef.current);
+      //   console.log('currentIdx', currentIdx);
+      //   // Do something when user clicks back button
+      // } else {
+      //   console.log('NOTHING');
+      //   // console.log('prevStateRef', prevStateRef.current);
+      //   // console.log('currentState', currentState);
+      //   console.log('prevIdxRef', prevIdxRef.current);
+      //   console.log('currentIdx', currentIdx);
+      // }
+    };
+
+    window.addEventListener('popstate', handleHistoryChange);
+    return () => {
+      window.removeEventListener('popstate', handleHistoryChange);
+    };
+  }, [currentState, dispatch, state]);
 
   function handleBreadClick({ id, url }) {
     dispatch(removeBreadcrumb(id));
     setSearchParams(`${url}`);
   }
+
   return (
     <Box display="flex" alignItems="center" mb="xs">
       {state.length > 0 ? (
@@ -42,7 +94,7 @@ function Breadcrumbs(props = {}) {
           );
         }
         return (
-          <>
+          <React.Fragment key={item.id}>
             <Box display="flex" color="text.secondary" mx="xxs">
               <CaretRight />
             </Box>
@@ -52,7 +104,7 @@ function Breadcrumbs(props = {}) {
               title={item.title}
               onClick={() => handleBreadClick({ id: item.id, url: item.url })}
             />
-          </>
+          </React.Fragment>
         );
       })}
     </Box>

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -21,21 +21,25 @@ function Breadcrumbs(props = {}) {
     console.log('prevStateRef useEffect', prevStateRef.current);
     console.log('state useEffect', state);
     const handleHistoryChange = () => {
-      // console.log('prevStateRef popstate', prevStateRef.current);
-      // console.log('state popstate', state);
+      console.log('prevStateRef popstate', prevStateRef.current);
+      console.log('state popstate', state);
       if (currentState) {
         // prevStateRef.current = prevStateRef.current.pop();
-        dispatch(setBreadcrumb(prevStateRef.current.slice(0, -1)));
+        if (prevStateRef.current.length > state.length) {
+          console.log('FORWARD');
+          dispatch(setBreadcrumb(prevStateRef.current));
+          prevStateRef.current = state;
+        } else {
+          console.log('BACKWARD');
+          prevStateRef.current = state;
+          dispatch(setBreadcrumb(prevStateRef.current.slice(0, -1)));
+        }
       }
-      // if (prevStateRef.current === state) {
-      //   console.log('FORWARD');
-      // }
     };
+    window.addEventListener('popstate', handleHistoryChange);
     console.log('prevStateRef Before update:', prevStateRef.current);
-    prevStateRef.current = state;
     console.log('prevStateRef After update:', prevStateRef.current);
 
-    window.addEventListener('popstate', handleHistoryChange);
     return () => {
       window.removeEventListener('popstate', handleHistoryChange);
     };

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -15,41 +15,31 @@ function Breadcrumbs(props = {}) {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [state, dispatch] = useBreadcrumb();
-  //use back and forward states???
   const prevStateRef = useRef(state);
   const currentState = state[state.length - 1];
-  console.log(location);
 
   useEffect(() => {
     if (location.search === '') {
       dispatch(resetBreadcrumb());
     }
-    console.log('prevStateRef useEffect', prevStateRef.current);
-    console.log('state useEffect', state);
     const handleHistoryChange = () => {
-      console.log('prevStateRef popstate', prevStateRef.current);
-      console.log('state popstate', state);
       if (currentState) {
-        // prevStateRef.current = prevStateRef.current.pop();
         if (prevStateRef.current.length > state.length) {
-          console.log('FORWARD');
           dispatch(setBreadcrumb(prevStateRef.current));
           prevStateRef.current = state;
         } else {
-          console.log('BACKWARD');
           prevStateRef.current = state;
           dispatch(setBreadcrumb(prevStateRef.current.slice(0, -1)));
         }
       }
     };
     window.addEventListener('popstate', handleHistoryChange);
-    console.log('prevStateRef Before update:', prevStateRef.current);
-    console.log('prevStateRef After update:', prevStateRef.current);
 
     return () => {
       window.removeEventListener('popstate', handleHistoryChange);
     };
-  }, [currentState, dispatch, state]);
+  }, [state]);
+
   function handleBreadClick({ id, url }) {
     dispatch(removeBreadcrumb(id));
     setSearchParams(`${url}`);

--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { CaretRight } from 'phosphor-react';
 import { Box, Button, SystemText } from '../../ui-kit';
 import {
@@ -12,12 +12,18 @@ import {
 
 function Breadcrumbs(props = {}) {
   const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const [state, dispatch] = useBreadcrumb();
+  //use back and forward states???
   const prevStateRef = useRef(state);
   const currentState = state[state.length - 1];
+  console.log(location);
 
   useEffect(() => {
+    if (location.search === '') {
+      dispatch(resetBreadcrumb());
+    }
     console.log('prevStateRef useEffect', prevStateRef.current);
     console.log('state useEffect', state);
     const handleHistoryChange = () => {
@@ -44,7 +50,6 @@ function Breadcrumbs(props = {}) {
       window.removeEventListener('popstate', handleHistoryChange);
     };
   }, [currentState, dispatch, state]);
-
   function handleBreadClick({ id, url }) {
     dispatch(removeBreadcrumb(id));
     setSearchParams(`${url}`);

--- a/src/components/ContentSingle.js
+++ b/src/components/ContentSingle.js
@@ -101,7 +101,6 @@ function ContentSingle(props = {}) {
   );
 
   const handleActionPress = (item) => {
-    console.log(item);
     dispatch(
       addBreadcrumb({
         url: `?id=${getURLFromType(item)}`,

--- a/src/components/ContentSingle.js
+++ b/src/components/ContentSingle.js
@@ -8,6 +8,10 @@ import { useNavigate } from 'react-router-dom';
 import { getURLFromType, parseDescriptionLinks } from '../utils';
 import FeatureFeed from './FeatureFeed';
 import FeatureFeedComponentMap from './FeatureFeed/FeatureFeedComponentMap';
+import {
+  add as addBreadcrumb,
+  useBreadcrumb,
+} from '../providers/BreadcrumbProvider';
 
 import {
   Box,
@@ -26,6 +30,7 @@ import VideoPlayer from './VideoPlayer';
 
 function ContentSingle(props = {}) {
   const navigate = useNavigate();
+  const [state, dispatch] = useBreadcrumb();
 
   const invalidPage = !props.loading && !props.data;
 
@@ -96,6 +101,13 @@ function ContentSingle(props = {}) {
   );
 
   const handleActionPress = (item) => {
+    console.log(item);
+    dispatch(
+      addBreadcrumb({
+        url: `?id=${getURLFromType(item)}`,
+        title: item.title,
+      })
+    );
     navigate({
       pathname: '/',
       search: `?id=${getURLFromType(item)}`,

--- a/src/embeds/FeatureFeed.js
+++ b/src/embeds/FeatureFeed.js
@@ -10,7 +10,6 @@ import {
   ContentSingle,
   FeatureFeedList,
   ContentChannel,
-  Breadcrumbs,
   LivestreamSingle,
 } from '../components';
 import { Box } from '../ui-kit';

--- a/src/embeds/FeatureFeed.js
+++ b/src/embeds/FeatureFeed.js
@@ -91,7 +91,6 @@ const FeatureFeed = (props) => {
 
   return (
     <Box>
-      <Breadcrumbs />
       <RenderFeatures {...props} />
     </Box>
   );

--- a/src/providers/BreadcrumbProvider.js
+++ b/src/providers/BreadcrumbProvider.js
@@ -9,6 +9,7 @@ const initialState = [];
 const actionTypes = {
   add: 'add',
   remove: 'remove',
+  reset: 'reset',
 };
 
 const add = (payload) => ({
@@ -19,6 +20,10 @@ const add = (payload) => ({
 const remove = (payload) => ({
   type: 'remove',
   payload,
+});
+
+const reset = () => ({
+  type: 'reset',
 });
 
 function reducer(state, action) {
@@ -105,4 +110,5 @@ export {
   actionTypes,
   add,
   remove,
+  reset,
 };

--- a/src/providers/BreadcrumbProvider.js
+++ b/src/providers/BreadcrumbProvider.js
@@ -10,6 +10,7 @@ const actionTypes = {
   add: 'add',
   remove: 'remove',
   reset: 'reset',
+  set: 'set',
 };
 
 const add = (payload) => ({
@@ -19,6 +20,11 @@ const add = (payload) => ({
 
 const remove = (payload) => ({
   type: 'remove',
+  payload,
+});
+
+const set = (payload) => ({
+  type: 'set',
   payload,
 });
 
@@ -45,7 +51,10 @@ function reducer(state, action) {
       const dropRight = (arr, n = 1) => arr.slice(0, -n);
       return dropRight(state, action.payload + 1);
     }
-
+    case actionTypes.set: {
+      console.log('Returning this payload:', action.payload);
+      return action.payload;
+    }
     case actionTypes.reset: {
       return initialState;
     }
@@ -111,4 +120,5 @@ export {
   add,
   remove,
   reset,
+  set,
 };


### PR DESCRIPTION
## Basecamp Scope

[Breadcrumbs not working correctly with browser back button and using keyboard `cmd left arrow`](https://3.basecamp.com/3926363/buckets/27088350/todos/6018447603)


## What was done?

1. Added useEffect to breadcrumb component
2. Listens for `popstate` event. Removes last item of state
3. Breadcrumb should now disappear when it's suppose to (at the root)

_Note: The breadcrumb also resets when the user goes forward as well, looking into fix for that_

Before:

https://user-images.githubusercontent.com/68402088/231886734-69cd3ab0-7f14-4ed3-baa3-d0b5c1f56a21.mov

After:

https://user-images.githubusercontent.com/68402088/231886753-693e7041-b046-44c2-b2fa-c4e3b02ae739.mov

