### PR TITLE
[💻 Web Embed] Fix styling for children content items

### DIFF
--- a/src/components/ContentSingle.js
+++ b/src/components/ContentSingle.js
@@ -195,9 +195,9 @@ function ContentSingle(props = {}) {
               display="grid"
               gridGap="30px"
               gridTemplateColumns={{
-                _: 'repeat(1, 1fr)',
-                md: 'repeat(2, 1fr)',
-                lg: 'repeat(3, 1fr)',
+                _: 'repeat(1, minmax(0, 1fr));',
+                md: 'repeat(2, minmax(0, 1fr));',
+                lg: 'repeat(3, minmax(0, 1fr));',
               }}
               padding={{
                 _: '30px',

--- a/src/components/ContentSingle.js
+++ b/src/components/ContentSingle.js
@@ -190,10 +190,19 @@ function ContentSingle(props = {}) {
         {hasChildContent ? (
           <Box mb="l">
             <H3 mb="xs">{props.feature?.title}</H3>
+
             <Box
               display="grid"
-              gridTemplateColumns="repeat(3, 1fr)"
-              gridGap="20px"
+              gridGap="30px"
+              gridTemplateColumns={{
+                _: 'repeat(1, 1fr)',
+                md: 'repeat(2, 1fr)',
+                lg: 'repeat(3, 1fr)',
+              }}
+              padding={{
+                _: '30px',
+                md: '0',
+              }}
             >
               {childContentItems?.map((item, index) => (
                 <MediaItem


### PR DESCRIPTION
## Basecamp Scope
[[💻 Web Embed] Fix styling for children content items](https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6056739057/)

## What was done?

1. Fix styling on child content items for `ContentSingle`

Before:

https://user-images.githubusercontent.com/68402088/233153563-74043a39-6091-4eeb-a35d-7c5efc63c68f.mov

After:

https://user-images.githubusercontent.com/68402088/233153404-1978bd07-a26a-4b82-940c-2a2417c2a08a.mov



