### PR TITLE
[💻 Web Embeds] Onboarding flow to add profile information is broken.

### DIFF
--- a/src/components/Auth/AuthDetails.js
+++ b/src/components/Auth/AuthDetails.js
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 
-import { useForm, useUpdateProfileFields, useCurrentUser } from '../../hooks';
+import {
+  useForm,
+  useUpdateProfileFields,
+  useCurrentUser,
+  useCompleteRegister,
+} from '../../hooks';
 import { update as updateAuth, useAuth } from '../../providers/AuthProvider';
 import { Box, Button, Input, Select } from '../../ui-kit';
 import authSteps from '../Auth/authSteps';
@@ -17,6 +22,7 @@ function AuthDetails() {
   const [user, setUser] = useState(null);
   const [state, dispatch] = useAuth();
   const [updateProfileFields] = useUpdateProfileFields();
+  const [completeRegister] = useCompleteRegister();
   const { currentUser } = useCurrentUser();
 
   useEffect(() => {
@@ -43,6 +49,8 @@ function AuthDetails() {
         })
       );
       await updateProfileFields({ variables: { input: userProfile } });
+      await completeRegister(user.id);
+
       dispatch(updateAuth({ step: authSteps.Success }));
     } catch (e) {
       onError(e);

--- a/src/components/Auth/AuthDetails.js
+++ b/src/components/Auth/AuthDetails.js
@@ -49,7 +49,7 @@ function AuthDetails() {
         })
       );
       await updateProfileFields({ variables: { input: userProfile } });
-      await completeRegister(user.id);
+      await completeRegister();
 
       dispatch(updateAuth({ step: authSteps.Success }));
     } catch (e) {


### PR DESCRIPTION
## Basecamp Scope

[[💻 Web Embeds] Onboarding flow to add profile information is broken.](https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6049699732)

## What was done?

1. run complete Register hook during auth details step to set a apollos user to `TRUE` as well a get a rock id

