### PR TITLE
make profile fullscreen on mobile

### DIFF
--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -46,8 +46,16 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
       <Styled.Profile>
         <Card
           p="xs"
-          borderRadius="xxl"
-          width="520px"
+          borderRadius={{
+            _: '0%',
+            sm: 'xxl',
+          }}
+          width={{
+            _: '100%',
+            sm: '350px',
+            md: '520px',
+          }}
+          height="100%"
           border="1px solid rgba(0, 0, 0, 0.1)"
         >
           <Box display="flex" alignItems="center" justifyContent="end">

--- a/src/components/Profile/Profile.styles.js
+++ b/src/components/Profile/Profile.styles.js
@@ -11,6 +11,14 @@ const Profile = withTheme(styled.div`
   z-index: 9999;
   transition: opacity 0.3s ease;
   position: absolute;
+
+  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+    position: fixed;
+    bottom: 0;
+    top: 0;
+    right: 0;
+    left: 0;
+  }
   ${system};
 `);
 


### PR DESCRIPTION
## Basecamp Scope

[Add mobile-responsiveness to Profile Menu](https://3.basecamp.com/3926363/buckets/27088350/todos/6145566087/edit?replace=true)

## What was done?

1. Made profile modal full screen on modal


Before:

_Modal cut off on sides, cant click on the "x"_
<img width="342" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/f97c0205-fab2-422a-afb8-89f780af0ea6">

After:

https://github.com/ApollosProject/apollos-embeds/assets/68402088/039779b5-f6b1-4488-82f3-5565f375f938

