### PR TITLE
Add mobile ad links

### DIFF
--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -3,6 +3,7 @@ import { systemPropTypes, utils } from '../../ui-kit';
 import { withTheme } from 'styled-components';
 import { AuthManager } from '../../components';
 import ProfileDetails from './ProfileDetails';
+import { Link } from 'react-router-dom';
 
 import {
   Button,
@@ -25,12 +26,13 @@ import {
 } from 'phosphor-react';
 import Styled from './Profile.styles';
 
-import { useCurrentUser } from '../../hooks';
+import { useCurrentUser, useCurrentChurch } from '../../hooks';
 import themeGet from '@styled-system/theme-get';
 import { logout, useAuth } from '../../providers/AuthProvider';
 
 const Profile = ({ theme, handleCloseProfile, ...rest }) => {
   const { currentUser } = useCurrentUser();
+  const { currentChurch } = useCurrentChurch();
 
   const [state, dispatch] = useAuth();
   const [showAuth, setShowAuth] = useState(false);
@@ -130,7 +132,9 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
             <ProfileDetails setShowDetails={setShowDetails} />
           ) : null}
           {/* Mobile App Ad */}
-          {!showDetails ? (
+          {!showDetails &&
+          (currentChurch.mobileAppStoreUrl ||
+            currentChurch.mobilePlayStoreUrl) ? (
             <>
               <Box
                 alignItems="center"
@@ -156,25 +160,32 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
                 </BodyText>
               </Box>
               <Box display="flex" justifyContent="center">
-                <Button
-                  variant="secondary"
-                  title="Get it on iOS"
-                  size="small"
-                  onClick={() => {}}
-                  color="text.action"
-                  borderRadius="100px"
-                  icon={<AppleLogo weight="fill" size="24" />}
-                  mr="s"
-                />
-                <Button
-                  variant="secondary"
-                  title="Get it on Android"
-                  size="small"
-                  onClick={() => {}}
-                  color="text.action"
-                  borderRadius="100px"
-                  icon={<AndroidLogo weight="fill" size="24" />}
-                />
+                {currentChurch.mobileAppStoreUrl ? (
+                  <Link to={currentChurch.mobileAppStoreUrl}>
+                    <Button
+                      variant="secondary"
+                      title="Get it on iOS"
+                      size="small"
+                      color="text.action"
+                      borderRadius="100px"
+                      icon={<AppleLogo weight="fill" size="24" />}
+                      mr="s"
+                    />
+                  </Link>
+                ) : null}
+                {currentChurch.mobilePlayStoreUrl ? (
+                  <Link to={currentChurch.mobilePlayStoreUrl}>
+                    <Button
+                      variant="secondary"
+                      title="Get it on Android"
+                      size="small"
+                      type="button"
+                      color="text.action"
+                      borderRadius="100px"
+                      icon={<AndroidLogo weight="fill" size="24" />}
+                    />
+                  </Link>
+                ) : null}
               </Box>
             </>
           ) : null}

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,6 +2,7 @@ import useAuthQuery from './useAuthQuery';
 import useCompleteRegister from './useCompleteRegister';
 import useContentFeed from './useContentFeed';
 import useContentItem from './useContentItem';
+import useCurrentChurch from './useCurrentChurch';
 import useCurrentUser from './useCurrentUser';
 import useFeatureFeed from './useFeatureFeed';
 import useForm from './useForm';
@@ -21,6 +22,7 @@ export {
   useCompleteRegister,
   useContentFeed,
   useContentItem,
+  useCurrentChurch,
   useCurrentUser,
   useFeatureFeed,
   useForm,

--- a/src/hooks/useCurrentChurch.js
+++ b/src/hooks/useCurrentChurch.js
@@ -1,0 +1,28 @@
+import { gql, useQuery } from '@apollo/client';
+
+export const GET_CURRENT_CHURCH = gql`
+  query {
+    currentChurch {
+      mobileAppStoreUrl
+      mobilePlayStoreUrl
+      name
+      slug
+      theme
+    }
+  }
+`;
+
+function useCurrentChurch(options = {}) {
+  const query = useQuery(GET_CURRENT_CHURCH, {
+    fetchPolicy: 'cache-and-network',
+    errorPolicy: 'all',
+    ...options,
+  });
+
+  return {
+    currentChurch: query.data.currentChurch,
+    ...query,
+  };
+}
+
+export default useCurrentChurch;


### PR DESCRIPTION

## Basecamp Scope
[Add store links to the Profile Menu Mobile Ad buttons](https://3.basecamp.com/3926363/buckets/27088350/todos/6159624984/edit?replace=true)

## What was done?
Added mobile links to the Mobile ad buttons
If there are no links the mobile ad will not show
Added a new hook for currentChurch that queries for the links, slug, name, and theme of the church.

https://github.com/ApollosProject/apollos-embeds/assets/2528817/dcc56924-2bbc-4920-9d2f-b0b1f0f761f7

