### PR TITLE
Add facet filters to pages search

### DIFF
--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -211,6 +211,7 @@ export default function Autocomplete({
                     indexName: `WebPages_Global`,
                     query,
                     params: {
+                      facetFilters: [`church:${searchState.church}`],
                       hitsPerPage: 4,
                       clickAnalytics: true,
                       // highlightPreTag: '<mark>',


### PR DESCRIPTION
### Basecamp TODO
[Query Result State: Page Search Results](https://3.basecamp.com/3926363/buckets/27088350/todos/6159604550/edit?replace=true)

### What this does
This makes it so we are only searching church specific content in the WebPages_Global index.