### PR TITLE
Search bar fi

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -48,10 +48,9 @@ const Modal = (props = {}) => {
               <Box width={{ _: '0', sm: '10%' }}></Box>
               <Box
                 width={{
-                  _: '260px',
-                  sm: '275px',
-                  md: '520px',
-                  lg: '700px',
+                  _: '100%',
+                  md: '700px',
+                  lg: '900px',
                 }}
                 mx="auto"
                 justifyContent="center"

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -49,7 +49,7 @@ const Modal = (props = {}) => {
               <Box
                 width={{
                   _: '260px',
-                  sm: '350px',
+                  sm: '275px',
                   md: '520px',
                   lg: '700px',
                 }}

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -1,6 +1,11 @@
 import React, { useEffect, createElement, Fragment } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ClockCounterClockwise, MagnifyingGlass } from 'phosphor-react';
+import {
+  ClockCounterClockwise,
+  MagnifyingGlass,
+  CaretDown,
+  X,
+} from 'phosphor-react';
 
 import algoliasearch from 'algoliasearch/lite';
 import { createAutocomplete } from '@algolia/autocomplete-core';
@@ -155,6 +160,26 @@ export default function Autocomplete({
     });
   };
 
+  const clearInput = () => {
+    const value = inputProps.value;
+    recentSearchesPlugin.data.addItem({
+      id: value,
+      label: value,
+      _highLightResult: { label: { value: value } },
+    });
+    autocomplete.setQuery('');
+    autocomplete.refresh();
+  };
+
+  const handlePanelDropdown = () => {
+    const updatedAutocompleteState = { ...autocompleteState };
+    updatedAutocompleteState.isOpen = !updatedAutocompleteState.isOpen;
+    setAutocompleteState(updatedAutocompleteState);
+
+    autocomplete.setIsOpen(!autocompleteState.isOpen);
+    inputRef.current?.[autocompleteState.isOpen ? 'blur' : 'focus']();
+  };
+
   // Query Suggesion Index Definition
   const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     searchClient,
@@ -242,7 +267,6 @@ export default function Autocomplete({
   containerProps['aria-labelledby'] = autoCompleteLabel;
   inputProps['aria-labelledby'] = autoCompleteLabel;
   panelProps['aria-labelledby'] = autoCompleteLabel;
-
   useEffect(() => {
     function handleClickOutside(event) {
       if (autocompleteState.isOpen && !event.target.closest('#search')) {
@@ -267,6 +291,14 @@ export default function Autocomplete({
         {...autocomplete.getFormProps({ inputElement: inputRef.current })}
       >
         <input ref={inputRef} className="aa-Input" {...inputProps} />
+        {inputProps.value.trim() !== '' ? (
+          <div className="aa-ClearButton" onClick={clearInput}>
+            <X size={18} weight="fill" />
+          </div>
+        ) : null}
+        <div onClick={handlePanelDropdown}>
+          <CaretDown size={14} weight="fill" color="#27272E54" />
+        </div>
       </form>
       <div className="aa-Panel" {...autocomplete.getPanelProps({})}>
         {autocompleteState.isOpen &&

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -4,6 +4,7 @@ import {
   ClockCounterClockwise,
   MagnifyingGlass,
   CaretDown,
+  CaretRight,
   X,
 } from 'phosphor-react';
 
@@ -80,21 +81,7 @@ function QuerySuggestionItem({ item, autocomplete, handleActionPress }) {
             autocomplete.refresh();
           }}
         >
-          <svg
-            width="8"
-            height="17"
-            viewBox="0 0 10 18"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1 1.5L8.5 9L1 16.5"
-              stroke="#AFAFB3"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <CaretRight size={24} weight="bold" />
         </button>
       </div>
     </Box>
@@ -147,21 +134,7 @@ function PastQueryItem({ item, autocomplete }) {
             onTapAhead(item);
           }}
         >
-          <svg
-            width="8"
-            height="17"
-            viewBox="0 0 10 18"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M1 1.5L8.5 9L1 16.5"
-              stroke="#AFAFB3"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          <CaretRight size={24} weight="bold" />
         </button>
       </div>
     </Box>
@@ -286,11 +259,15 @@ export default function Autocomplete({
   const containerProps = autocomplete.getRootProps({});
   const inputProps = autocomplete.getInputProps({});
   const panelProps = autocomplete.getPanelProps({});
+  const formProps = autocomplete.getFormProps({
+    inputElement: inputRef.current,
+  });
 
   inputProps.id = autoCompleteId;
   containerProps['aria-labelledby'] = autoCompleteLabel;
   inputProps['aria-labelledby'] = autoCompleteLabel;
   panelProps['aria-labelledby'] = autoCompleteLabel;
+
   useEffect(() => {
     function handleClickOutside(event) {
       if (autocompleteState.isOpen && !event.target.closest('#search')) {
@@ -310,12 +287,9 @@ export default function Autocomplete({
   // ...CUSTOM RENDERER
   return (
     <div className="aa-Autocomplete" {...containerProps}>
-      <form
-        className="aa-Form"
-        {...autocomplete.getFormProps({ inputElement: inputRef.current })}
-      >
+      <form className="aa-Form" {...formProps}>
         <input ref={inputRef} className="aa-Input" {...inputProps} />
-        {inputProps.value.trim() !== '' ? (
+        {inputProps.value !== '' ? (
           <div className="aa-ClearButton" onClick={clearInput}>
             <X size={18} weight="fill" />
           </div>
@@ -387,7 +361,12 @@ export default function Autocomplete({
             return autocompleteState.query !== '' ? (
               <div key={`source-${index}`} className="aa-Source">
                 {collection.source.sourceId === 'content' && (
-                  <Box padding="xs" fontWeight="600" color="#27272E99">
+                  <Box
+                    padding="xs"
+                    fontWeight="600"
+                    color="#27272E99"
+                    id="results"
+                  >
                     Content
                   </Box>
                 )}

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -295,7 +295,9 @@ export default function Autocomplete({
           </div>
         ) : null}
         <div onClick={handlePanelDropdown}>
-          <CaretDown size={14} weight="fill" color="#27272E54" />
+          <Box color="base.gray">
+            <CaretDown size={14} weight="fill" />
+          </Box>
         </div>
       </form>
       <Box
@@ -364,14 +366,14 @@ export default function Autocomplete({
                   <Box
                     padding="xs"
                     fontWeight="600"
-                    color="#27272E99"
+                    color="base.gray"
                     id="results"
                   >
                     Content
                   </Box>
                 )}
                 {collection.source.sourceId === 'pages' && (
-                  <Box padding="xs" fontWeight="600" color="#27272E99">
+                  <Box padding="xs" fontWeight="600" color="base.gray">
                     Pages
                   </Box>
                 )}

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -18,7 +18,7 @@ import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 import '@algolia/autocomplete-theme-classic';
 
-import { ResourceCard } from '../../ui-kit';
+import { ResourceCard, Box } from '../../ui-kit';
 import { useSearchState } from '../../providers/SearchProvider';
 import { getURLFromType } from '../../utils';
 
@@ -55,10 +55,10 @@ const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
 // Query Suggestion Item Render
 function QuerySuggestionItem({ item, autocomplete, handleActionPress }) {
   return (
-    <div className="aa-ItemWrapper">
+    <Box className="aa-ItemWrapper" px="xs">
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
-          <MagnifyingGlass size={32} />
+          <MagnifyingGlass size={24} weight="bold" />
         </div>
         <div className="aa-ItemContentBody">
           <div
@@ -80,12 +80,24 @@ function QuerySuggestionItem({ item, autocomplete, handleActionPress }) {
             autocomplete.refresh();
           }}
         >
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z" />
+          <svg
+            width="8"
+            height="17"
+            viewBox="0 0 10 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1 1.5L8.5 9L1 16.5"
+              stroke="#AFAFB3"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         </button>
       </div>
-    </div>
+    </Box>
   );
 }
 
@@ -101,10 +113,10 @@ function PastQueryItem({ item, autocomplete }) {
     autocomplete.refresh();
   }
   return (
-    <div className="aa-ItemWrapper">
+    <Box className="aa-ItemWrapper" px="xs">
       <div className="aa-ItemContent">
         <div className="aa-ItemIcon aa-ItemIcon--noBorder">
-          <ClockCounterClockwise size={32} weight="fill" />
+          <ClockCounterClockwise size={24} weight="bold" />
         </div>
         <div className="aa-ItemContentBody">
           <div className="aa-ItemContentTitle">
@@ -135,12 +147,24 @@ function PastQueryItem({ item, autocomplete }) {
             onTapAhead(item);
           }}
         >
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M8 17v-7.586l8.293 8.293c0.391 0.391 1.024 0.391 1.414 0s0.391-1.024 0-1.414l-8.293-8.293h7.586c0.552 0 1-0.448 1-1s-0.448-1-1-1h-10c-0.552 0-1 0.448-1 1v10c0 0.552 0.448 1 1 1s1-0.448 1-1z" />
+          <svg
+            width="8"
+            height="17"
+            viewBox="0 0 10 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M1 1.5L8.5 9L1 16.5"
+              stroke="#AFAFB3"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         </button>
       </div>
-    </div>
+    </Box>
   );
 }
 
@@ -358,13 +382,22 @@ export default function Autocomplete({
             return autocompleteState.query !== '' ? (
               <div key={`source-${index}`} className="aa-Source">
                 {collection.source.sourceId === 'content' && (
-                  <span>Content</span>
+                  <Box padding="xs" fontWeight="600" color="#27272E99">
+                    Content
+                  </Box>
                 )}
-                {collection.source.sourceId === 'pages' && <span>Pages</span>}
+                {collection.source.sourceId === 'pages' && (
+                  <Box padding="xs" fontWeight="600" color="#27272E99">
+                    Pages
+                  </Box>
+                )}
                 {items.length > 0 && (
                   <ul className="aa-List" {...autocomplete.getListProps()}>
                     {items.map((item) => (
-                      <li
+                      <Box
+                        as="li"
+                        borderRadius="0"
+                        padding="0"
                         key={item.objectID}
                         className="aa-Item"
                         {...autocomplete.getItemProps({
@@ -378,7 +411,7 @@ export default function Autocomplete({
                           onClick={() => handleActionPress(item)}
                           background="none"
                         />
-                      </li>
+                      </Box>
                     ))}
                   </ul>
                 )}

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -324,7 +324,12 @@ export default function Autocomplete({
           <CaretDown size={14} weight="fill" color="#27272E54" />
         </div>
       </form>
-      <div className="aa-Panel" {...autocomplete.getPanelProps({})}>
+      <Box
+        id="panel"
+        className="aa-Panel"
+        dropdown={autocompleteState.isOpen}
+        {...autocomplete.getPanelProps({})}
+      >
         {autocompleteState.isOpen &&
           autocompleteState.collections.map((collection, index) => {
             const { source, items } = collection;
@@ -421,7 +426,7 @@ export default function Autocomplete({
         {autocompleteState.isOpen && autocompleteState.query === '' ? (
           <span>****Insert Features here****</span>
         ) : null}
-      </div>
+      </Box>
     </div>
   );
 }

--- a/src/components/Searchbar/Search.styles.js
+++ b/src/components/Searchbar/Search.styles.js
@@ -32,6 +32,9 @@ const showPanel = ({ dropdown }) => {
       @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
         height: 100vh;
       }
+      @media screen and (min-width: ${themeGet('breakpoints.sm')}) {
+        height: 600px;
+      }
     `;
   } else {
     return css`

--- a/src/components/Searchbar/Search.styles.js
+++ b/src/components/Searchbar/Search.styles.js
@@ -26,6 +26,20 @@ const showDropdown = ({ dropdown }) => {
   }
 };
 
+const showPanel = ({ dropdown }) => {
+  if (dropdown) {
+    return css`
+      @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+        height: 100vh;
+      }
+    `;
+  } else {
+    return css`
+      height: 0px;
+    `;
+  }
+};
+
 const Wrapper = withTheme(styled.div`
   align-items: center;
   background: ${themeGet('colors.base.white')};
@@ -46,6 +60,9 @@ const Wrapper = withTheme(styled.div`
     left: 0;
     background: ${themeGet('colors.base.white')};
     box-shadow: ${themeGet('shadows.medium')};
+    transition: 0s;
+    overflow: scroll;
+    ${showPanel}
   }
 
   .aa-Form:focus-within {
@@ -68,6 +85,14 @@ const TextPrompt = withTheme(styled.div`
   transform: translate(0, -50%);
   white-space: nowrap;
   width: 100%;
+
+  @media screen and (max-width: ${themeGet('breakpoints.md')}) {
+    max-width: 50%;
+  }
+
+  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+    max-width: 47%;
+  }
 
   ${system}
 `);

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -13,8 +13,6 @@ import Autocomplete from '../Searchbar/Autocomplete';
 const MOBILE_BREAKPOINT = 428;
 
 const Searchbar = (props = {}) => {
-  // const [showDropdown, setShowDropdown] = useState(false);
-  // const [inputValue, setInputValue] = useState('');
   const [showProfile, setShowProfile] = useState(false);
   const [showTextPrompt, setShowTextPrompt] = useState(true);
   const [autocompleteState, setAutocompleteState] = React.useState({
@@ -74,33 +72,6 @@ const Searchbar = (props = {}) => {
     }
   }, [autocompleteState.isOpen]);
 
-  // const handleX = () => {
-  //   console.log(autocompleteState);
-  //   if (isMobile) {
-  //     setShowDropdown(false);
-  //     if (autocompleteState.query.trim() === '') {
-  //       setShowTextPrompt(true);
-  //     }
-  //   } else {
-  //     setInputValue('');
-  //   }
-  // };
-
-  // const handleInputChange = (event) => {
-  //   const value = event.target.value;
-  //   setInputValue(value);
-  //   const dropdown = document.querySelector('#dropdown');
-
-  //   if (value.trim() === '') {
-  //     // Input is empty, do something
-  //   } else {
-  //     // Input is not empty, do something else
-  //   }
-  //   if (isMobile && dropdown) {
-  //     dropdown.scrollTop = 0;
-  //   }
-  // };
-
   const handleProfile = () => {
     console.log('Opening Profile menu...');
     setShowProfile(!showProfile);
@@ -136,19 +107,6 @@ const Searchbar = (props = {}) => {
               {showTextPrompt ? textPrompt : null}
             </Box>
           </Styled.InterfaceWrapper>
-          {/* {autocompleteState.isOpen ? (
-            <Styled.X>
-              <X size={18} weight="fill" onClick={handleX} />
-            </Styled.X>
-          ) : null} */}
-          {/* <Box
-            px="xxs"
-            onClick={() => {
-              !isMobile && setShowDropdown(!showDropdown);
-            }}
-          >
-            <CaretDown size={14} weight="fill" color="#27272E54" />
-          </Box> */}
         </Styled.Interface>
         <Box padding="12px" onClick={handleProfile}>
           {currentUser?.profile?.photo?.uri ? (

--- a/src/components/Searchbar/Searchbar.js
+++ b/src/components/Searchbar/Searchbar.js
@@ -13,11 +13,19 @@ import Autocomplete from '../Searchbar/Autocomplete';
 const MOBILE_BREAKPOINT = 428;
 
 const Searchbar = (props = {}) => {
+  // const [showDropdown, setShowDropdown] = useState(false);
+  // const [inputValue, setInputValue] = useState('');
   const [showProfile, setShowProfile] = useState(false);
-  const [showDropdown, setShowDropdown] = useState(false);
   const [showTextPrompt, setShowTextPrompt] = useState(true);
-  const [inputValue, setInputValue] = useState('');
-  const [autocompleteState, setAutocompleteState] = React.useState({});
+  const [autocompleteState, setAutocompleteState] = React.useState({
+    activeItemId: null,
+    collections: [],
+    completion: null,
+    context: {},
+    isOpen: false,
+    query: '',
+    status: 'idle',
+  });
   const { currentUser } = useCurrentUser();
   const userExist = !!currentUser;
   const firstName = currentUser?.profile?.firstName || '';
@@ -66,31 +74,32 @@ const Searchbar = (props = {}) => {
     }
   }, [autocompleteState.isOpen]);
 
-  const handleX = () => {
-    if (isMobile) {
-      setShowDropdown(false);
-      if (inputValue.trim() === '') {
-        setShowTextPrompt(true);
-      }
-    } else {
-      setInputValue('');
-    }
-  };
+  // const handleX = () => {
+  //   console.log(autocompleteState);
+  //   if (isMobile) {
+  //     setShowDropdown(false);
+  //     if (autocompleteState.query.trim() === '') {
+  //       setShowTextPrompt(true);
+  //     }
+  //   } else {
+  //     setInputValue('');
+  //   }
+  // };
 
-  const handleInputChange = (event) => {
-    const value = event.target.value;
-    setInputValue(value);
-    const dropdown = document.querySelector('#dropdown');
+  // const handleInputChange = (event) => {
+  //   const value = event.target.value;
+  //   setInputValue(value);
+  //   const dropdown = document.querySelector('#dropdown');
 
-    if (value.trim() === '') {
-      // Input is empty, do something
-    } else {
-      // Input is not empty, do something else
-    }
-    if (isMobile && dropdown) {
-      dropdown.scrollTop = 0;
-    }
-  };
+  //   if (value.trim() === '') {
+  //     // Input is empty, do something
+  //   } else {
+  //     // Input is not empty, do something else
+  //   }
+  //   if (isMobile && dropdown) {
+  //     dropdown.scrollTop = 0;
+  //   }
+  // };
 
   const handleProfile = () => {
     console.log('Opening Profile menu...');
@@ -127,21 +136,21 @@ const Searchbar = (props = {}) => {
               {showTextPrompt ? textPrompt : null}
             </Box>
           </Styled.InterfaceWrapper>
-          {autocompleteState.isOpen ? (
+          {/* {autocompleteState.isOpen ? (
             <Styled.X>
               <X size={18} weight="fill" onClick={handleX} />
             </Styled.X>
-          ) : null}
-          <Box
+          ) : null} */}
+          {/* <Box
             px="xxs"
             onClick={() => {
               !isMobile && setShowDropdown(!showDropdown);
             }}
           >
             <CaretDown size={14} weight="fill" color="#27272E54" />
-          </Box>
+          </Box> */}
         </Styled.Interface>
-        <Box padding="12px 12px 12px 0;" onClick={handleProfile}>
+        <Box padding="12px" onClick={handleProfile}>
           {currentUser?.profile?.photo?.uri ? (
             <Avatar
               src={currentUser?.profile?.photo?.uri}

--- a/src/ui-kit/ResourceCard/ResourceCard.js
+++ b/src/ui-kit/ResourceCard/ResourceCard.js
@@ -86,10 +86,28 @@ function ResourceCard({
         {/* Title and Subtitle */}
         <Styled.Heading>
           <Styled.Title>
-            <Styled.Ellipse>{title}</Styled.Ellipse>
+            <Styled.Ellipse
+              width={{
+                _: '100px',
+                sm: '150px',
+                md: '350px',
+                lg: '500px',
+              }}
+            >
+              {title}
+            </Styled.Ellipse>
           </Styled.Title>
           <Styled.Subtitle>
-            <Styled.Ellipse>{subtitle}</Styled.Ellipse>
+            <Styled.Ellipse
+              width={{
+                _: '100px',
+                sm: '150px',
+                md: '350px',
+                lg: '500px',
+              }}
+            >
+              {subtitle}
+            </Styled.Ellipse>
           </Styled.Subtitle>
         </Styled.Heading>
 

--- a/src/ui-kit/ResourceCard/ResourceCard.styles.js
+++ b/src/ui-kit/ResourceCard/ResourceCard.styles.js
@@ -47,7 +47,7 @@ const Wrapper = withTheme(styled.div`
 const Heading = withTheme(styled.div`
   display: flex;
   flex-direction: column;
-  width: calc(100% - 55px);
+  width: 100%;
   ${system};
 `);
 
@@ -57,7 +57,7 @@ const Title = withTheme(styled.div`
   font-size: 16px;
   line-height: 24px;
   color: #27272e;
-  max-width: 100%;
+  width: 100%;
   padding-right: 3%;
   ${system};
 `);
@@ -68,16 +68,15 @@ const Subtitle = withTheme(styled.div`
   font-size: 14px;
   line-height: 20px;
   color: rgba(39, 39, 46, 0.6);
-  max-width: 100%;
+  width: 100%;
   padding-right: 3%;
   ${system};
 `);
 
 const Ellipse = withTheme(styled.div`
   display: inline-block;
-  max-width: 100%;
-  white-space: nowrap;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   ${system};
 `);


### PR DESCRIPTION
## Basecamp Scope

[Polish: Search Bar F&Is](https://3.basecamp.com/3926363/buckets/27088350/todos/6203786717/)

_Will handle scroll behavior in seperate branches_

## What was done?

1. Fix the styling to match whats in figma
2. Refactored the 'X' button to be inside the autocomplete component. Also using the 'X' will add the query to the user's recent searches
3. Refactored the caret dropdown to be inside the autocomplete component to trigger dropdown toggle
4. Changed the recent/suggested search to use the 'right caret icon' instead of the 'diagonal arrow' to match the resource cards and figma design below (can be changed back if needed)
5. add mobile responsiveness

<img width="512" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/30bc49d7-c189-4c8f-a0f2-4e4142fbbecd">

Styling + x + caret

https://github.com/ApollosProject/apollos-embeds/assets/68402088/9be7bc5c-3ab0-4cab-be55-71736d02d578

Mobile

https://github.com/ApollosProject/apollos-embeds/assets/68402088/891d36cd-e575-4ac8-97b2-e4b859f55cc0

