### PR TITLE
Feature feed refactor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,20 +29,20 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <!-- This is an example of how to use the apollos widgets -->
-    <!-- <div
+    <div
       data-church="chase_oaks"
       data-type="FeatureFeed"
-      data-feature-feed="FeatureFeed:eff5bdb8-3730-4564-a043-72a4c840c981"
-      data-search-feed="FeatureFeed:3e6dcb76-8c7e-42e2-a424-5f63d053f2bf"
+      data-feature-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
+      data-search-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
       data-modal="true"
       class="apollos-widget"
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
-    ></div> -->
+    ></div>
 
     <div
     data-church="apollos_demo"
     data-type="Search"
-    data-search-feed="FeatureFeed:3e6dcb76-8c7e-42e2-a424-5f63d053f2bf"
+    data-search-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
     data-modal="true"
     class="apollos-widget"
     style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,8 @@
     <!-- <div
       data-church="chase_oaks"
       data-type="FeatureFeed"
+      data-feature-feed="FeatureFeed:eff5bdb8-3730-4564-a043-72a4c840c981"
+      data-search-feed="FeatureFeed:3e6dcb76-8c7e-42e2-a424-5f63d053f2bf"
       data-modal="true"
       class="apollos-widget"
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
@@ -40,6 +42,7 @@
     <div
     data-church="apollos_demo"
     data-type="Search"
+    data-search-feed="FeatureFeed:3e6dcb76-8c7e-42e2-a424-5f63d053f2bf"
     data-modal="true"
     class="apollos-widget"
     style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,12 @@ function App(props) {
   const router = createBrowserRouter([
     {
       path: '/',
-      element: <WidgetComponent symbol={props.symbol} church={props.church} />,
+      element: (
+        <WidgetComponent
+          featureFeed={props.featureFeed}
+          church={props.church}
+        />
+      ),
       errorElement: <ErrorPage />,
     },
   ]);
@@ -32,7 +37,11 @@ function App(props) {
   // Widgets require a church slug to get the correct data
   if (WidgetComponent && props.church) {
     return (
-      <AppProvider church={props.church} modal={props.modal}>
+      <AppProvider
+        church={props.church}
+        modal={props.modal}
+        searchFeed={props.searchFeed}
+      >
         <RouterProvider router={router} />
       </AppProvider>
     );

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -13,6 +13,8 @@ import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 import '@algolia/autocomplete-theme-classic';
 
+import { FeatureFeedProvider } from '../../providers';
+import Feed from '../FeatureFeed';
 import { ResourceCard } from '../../ui-kit';
 import { useSearchState } from '../../providers/SearchProvider';
 import { getURLFromType } from '../../utils';
@@ -147,7 +149,6 @@ export default function Autocomplete({
   const navigate = useNavigate();
   const searchState = useSearchState();
   const inputRef = React.useRef(null);
-
   const handleActionPress = (item) => {
     navigate({
       pathname: '/',
@@ -354,7 +355,15 @@ export default function Autocomplete({
             ) : null;
           })}
         {autocompleteState.isOpen && autocompleteState.query === '' ? (
-          <span>****Insert Features here****</span>
+          // searchState.searchFeed
+          <FeatureFeedProvider
+            Component={Feed}
+            options={{
+              variables: {
+                itemId: searchState.searchFeed,
+              },
+            }}
+          />
         ) : null}
       </div>
     </div>

--- a/src/embeds/FeatureFeed.js
+++ b/src/embeds/FeatureFeed.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import {
-  TabFeedProvider,
   ContentItemProvider,
   FeatureFeedProvider,
   ContentFeedProvider,
 } from '../providers';
 import {
-  Feed,
   ContentSingle,
   FeatureFeedList,
   ContentChannel,
@@ -16,12 +14,10 @@ import {
 } from '../components';
 import { useModalState } from '../providers/ModalProvider';
 import { Box } from '../ui-kit';
-import { useCurrentUser } from '../hooks';
-import { useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 function RenderFeatures(props) {
   const [searchParams] = useSearchParams();
-  const { currentUser } = useCurrentUser();
   const _id = searchParams.get('id');
 
   const [type, randomId] = _id?.split(/-(.*)/s) ?? [];
@@ -72,12 +68,11 @@ function RenderFeatures(props) {
     default: {
       return (
         <Box>
-          <TabFeedProvider
-            Component={Feed}
+          <FeatureFeedProvider
+            Component={FeatureFeedList}
             options={{
               variables: {
-                campusId: currentUser?.campus?.id,
-                tab: 'TV',
+                itemId: props.featureFeed,
               },
             }}
             {...props}
@@ -90,19 +85,17 @@ function RenderFeatures(props) {
 
 const FeatureFeed = (props) => {
   const state = useModalState();
-  const { currentUser } = useCurrentUser();
 
   return (
     <Box>
       {state.modal ? (
         <Box>
           <Modal />
-          <TabFeedProvider
-            Component={Feed}
+          <FeatureFeedProvider
+            Component={FeatureFeedList}
             options={{
               variables: {
-                campusId: currentUser?.campus?.id,
-                tab: 'TV',
+                itemId: props.featureFeed,
               },
             }}
             {...props}

--- a/src/embeds/Search.js
+++ b/src/embeds/Search.js
@@ -2,13 +2,11 @@ import React from 'react';
 import { Searchbar } from '../components';
 
 import {
-  TabFeedProvider,
   ContentItemProvider,
   FeatureFeedProvider,
   ContentFeedProvider,
 } from '../providers';
 import {
-  Feed,
   ContentSingle,
   FeatureFeedList,
   ContentChannel,
@@ -18,12 +16,10 @@ import {
 } from '../components';
 import { useModalState } from '../providers/ModalProvider';
 import { Box } from '../ui-kit';
-import { useCurrentUser } from '../hooks';
-import { useSearchParams, useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 function RenderFeatures(props) {
   const [searchParams] = useSearchParams();
-  const { currentUser } = useCurrentUser();
   const _id = searchParams.get('id');
 
   const [type, randomId] = _id?.split(/-(.*)/s) ?? [];
@@ -83,7 +79,6 @@ function RenderFeatures(props) {
 
 const Search = (props) => {
   const state = useModalState();
-  const { currentUser } = useCurrentUser();
 
   return (
     <Box>

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ widgetDivs.forEach((div) => {
         symbol={div.dataset.symbol}
         type={div.dataset.type}
         church={div.dataset.church}
+        searchFeed={div.dataset.searchFeed}
+        featureFeed={div.dataset.featureFeed}
         modal={div.dataset.modal}
       />
     </React.StrictMode>,

--- a/src/providers/AppProvider.js
+++ b/src/providers/AppProvider.js
@@ -13,7 +13,7 @@ function AppProvider(props = {}) {
   return (
     <ApolloProvider client={client(props.church)} {...props}>
       <AuthProvider>
-        <SearchProvider church={props.church}>
+        <SearchProvider church={props.church} searchFeed={props.searchFeed}>
           <BreadcrumbProvider>
             <ModalProvider modal={props.modal}>
               <ThemeProvider>{props.children}</ThemeProvider>

--- a/src/providers/SearchProvider.js
+++ b/src/providers/SearchProvider.js
@@ -7,6 +7,7 @@ const SearchDispatchContext = createContext();
 // Define the initial state of the search
 const initialState = {
   church: null,
+  searchFeed: null,
 };
 
 // Define the actionTypes that can be performed on the search state
@@ -33,6 +34,7 @@ function SearchProvider(props = {}) {
   const [state, dispatch] = useReducer(reducer, {
     ...initialState, // spread the original initialState object
     church: props.church, // add church to state
+    searchFeed: props.searchFeed, // add search feed id to state
   });
 
   return (


### PR DESCRIPTION
### Basecamp TODO
[Empty Search State: Feature Feed](https://3.basecamp.com/3926363/buckets/27088350/todos/6093728369/edit?replace=true)

### What was done.

Adds feature feed to search and update FeatureFeed embed to use FeatureFeedProvider instead of TabFeedProvider. This PR wires up search and feature feed to work with feature feed ids. We currently don't have the actually feeds done for any church, but this proves that the functionality works. The feature id I'm using makes it look crappy but it is just for testing. Once the feeds are configured we can plug in the id and then create the last component based of the data. I think it will be a action link list or something like that. 

We will need the typename, id, and title/slug for that "feature/list of links". We should be able to use the ResourceCard component for the other features in the search dropdown.
<img width="498" alt="CleanShot 2023-06-02 at 11 30 57@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/5fc47825-0938-407a-8e99-70f795b44344">


## Current state of UI


<img width="821" alt="CleanShot 2023-06-02 at 11 21 28@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/0dda9726-29c9-469e-b71c-b7a6076b8aa8">
<img width="1163" alt="CleanShot 2023-06-02 at 11 22 13@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/3224cae2-bf78-4911-a750-a0acf8e70b69">
