### PR TITLE
Scroll behavior

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,7 +30,7 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <!-- This is an example of how to use the apollos widgets -->
     <div
-      data-church="chase_oaks"
+      data-church="apollos_demo"
       data-type="FeatureFeed"
       data-feature-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
       data-search-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
@@ -40,13 +40,13 @@
     ></div>
 
     <div
-    data-church="apollos_demo"
-    data-type="Search"
-    data-search-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
-    data-modal="true"
-    class="apollos-widget"
-    style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
-  ></div>
+      data-church="apollos_demo"
+      data-type="Search"
+      data-search-feed="FeatureFeed:236de524eceed43e49015f722298ef049d2bd72e8b00c64d62d153b5d90a4d3f592795e2a8d276c319bcf89721ffae4a"
+      data-modal="true"
+      class="apollos-widget"
+      style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
+    ></div>
     <!-- <div
       data-church="bayside"
       data-type="Auth"

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -25,6 +25,8 @@ import { ResourceCard, Box } from '../../ui-kit';
 
 import { useSearchState } from '../../providers/SearchProvider';
 import { getURLFromType } from '../../utils';
+import Styled from './Search.styles';
+
 const MOBILE_BREAKPOINT = 428;
 const appId = process.env.REACT_APP_ALGOLIA_APP_ID;
 const apiKey = process.env.REACT_APP_ALGOLIA_API_KEY;
@@ -316,13 +318,15 @@ export default function Autocomplete({
         <input ref={inputRef} className="aa-Input" {...inputProps} />
         {inputProps.value !== '' ? (
           <div className="aa-ClearButton" onClick={clearInput}>
-            <X size={18} weight="fill" />
+            <Styled.IconWrapper>
+              <X size={18} weight="fill" />
+            </Styled.IconWrapper>
           </div>
         ) : null}
         <div onClick={handlePanelDropdown}>
-          <Box color="base.gray">
+          <Styled.IconWrapper>
             <CaretDown size={14} weight="fill" />
-          </Box>
+          </Styled.IconWrapper>
         </div>
       </form>
       <Box

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -379,7 +379,7 @@ export default function Autocomplete({
                     Pages
                   </Box>
                 )}
-                {items.length > 0 && (
+                {items.length > 0 ? (
                   <ul className="aa-List" {...autocomplete.getListProps()}>
                     {items.map((item) => (
                       <Box
@@ -402,6 +402,16 @@ export default function Autocomplete({
                       </Box>
                     ))}
                   </ul>
+                ) : (
+                  <Box
+                    padding="xs"
+                    fontWeight="500"
+                    color="base.gray"
+                    textAlign="center"
+                    fontStyle="italic"
+                  >
+                    No results found
+                  </Box>
                 )}
               </div>
             ) : null;

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -179,6 +179,14 @@ export default function Autocomplete({
     inputRef.current?.[autocompleteState.isOpen ? 'blur' : 'focus']();
   };
 
+  const scrollToResults = (event) => {
+    const resultsElement = document.getElementById('results');
+    event.preventDefault();
+    if (resultsElement) {
+      resultsElement.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   // Query Suggesion Index Definition
   const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     searchClient,
@@ -266,6 +274,7 @@ export default function Autocomplete({
   });
 
   inputProps.id = autoCompleteId;
+  formProps.onSubmit = scrollToResults;
   containerProps['aria-labelledby'] = autoCompleteLabel;
   inputProps['aria-labelledby'] = autoCompleteLabel;
   panelProps['aria-labelledby'] = autoCompleteLabel;

--- a/src/components/Searchbar/Search.styles.js
+++ b/src/components/Searchbar/Search.styles.js
@@ -157,10 +157,20 @@ const Title = withTheme(styled(H4)`
   color: ${themeGet('colors.text.secondary')};
 `);
 
+const IconWrapper = withTheme(styled.div`
+  color: #27272e54;
+  &:hover {
+    color: ${themeGet('colors.base.secondary')};
+    cursor: pointer;
+  }
+  ${system}
+`);
+
 const Styled = {
   Input,
   Interface,
   InterfaceWrapper,
+  IconWrapper,
   Profile,
   SearchIcon,
   TextPrompt,


### PR DESCRIPTION
## Basecamp Scope

[Desktop Specific Behavior: Scroll to Results](https://3.basecamp.com/3926363/buckets/27088350/todos/6093749767/edit?replace=true)

[Mobile Specific Behavior: Anchor search field to top](https://3.basecamp.com/3926363/buckets/27088350/todos/6093757977/edit?replace=true)

## What was done?

1. When user presses enter on search bar, will scroll down to the results section (currently tagged on the Content title)
2. On mobile, new keystrokes will reset scroll to the top
3. Styling changes + no results message when no items are rendered

_Note: No completely satisfied with how the desktop behavior works with scrolling (it will scroll the browser window before scrolling the dropdown). If needed, can improve in future PR_

https://github.com/ApollosProject/apollos-embeds/assets/68402088/2141d803-dcde-4cd6-ad95-6f31059dc4c8



