### PR TITLE
(No Backend) Functional/UX Related QA

### DIFF
--- a/src/components/ContentSingle.js
+++ b/src/components/ContentSingle.js
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import DOMPurify from 'dompurify';
 import format from 'date-fns/format';
 import addMinutes from 'date-fns/addMinutes';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -95,8 +94,6 @@ function ContentSingle(props = {}) {
         'MMMM do, yyyy'
       )
     : null;
-
-  const sanitizedHTML = DOMPurify.sanitize(htmlContent);
 
   // We'll conditionally place this divider as needed
   const infoDivider = (
@@ -199,7 +196,7 @@ function ContentSingle(props = {}) {
             <>
               <Longform
                 dangerouslySetInnerHTML={{
-                  __html: parseDescriptionLinks(sanitizedHTML),
+                  __html: parseDescriptionLinks(htmlContent),
                 }}
               />
             </>

--- a/src/components/FeatureFeed/Features/ActionListFeature.js
+++ b/src/components/FeatureFeed/Features/ActionListFeature.js
@@ -20,9 +20,9 @@ function ActionListFeature(props = {}) {
         {props.feature.title}
       </Box>
       <Styled.List>
-        {props.feature?.actions?.map((item) => {
+        {props.feature?.actions?.map((item, index) => {
           return (
-            <Styled.Wrapper>
+            <Styled.Wrapper key={index}>
               <ResourceCard
                 title={item.title}
                 subtitle={item.subtitle}

--- a/src/components/FeatureFeed/Features/ButtonFeature.js
+++ b/src/components/FeatureFeed/Features/ButtonFeature.js
@@ -1,10 +1,10 @@
-import React from "react";
-import { withTheme } from "styled-components";
+import React from 'react';
+import { withTheme } from 'styled-components';
 
-import { useNavigate } from "react-router-dom";
-import { getURLFromType } from "../../../utils";
+import { useNavigate } from 'react-router-dom';
+import { getURLFromType } from '../../../utils';
 
-import { Button, systemPropTypes } from "../../../ui-kit";
+import { Button, systemPropTypes } from '../../../ui-kit';
 
 function ButtonFeature(props = {}) {
   const navigate = useNavigate();
@@ -12,16 +12,16 @@ function ButtonFeature(props = {}) {
   // Event Handlers
   const handleActionPress = () => {
     navigate({
-      pathname: "/",
+      pathname: '/',
       search: `?id=${getURLFromType(props.relatedNode)}`,
     });
   };
 
   return (
     <Button
-      title={props.title}
+      title={props.title || props.feature?.action?.title}
       icon={props.icon}
-      cursor={props.relatedNode ? "pointer" : "default"}
+      cursor={props.relatedNode ? 'pointer' : 'default'}
       onClick={props.relatedNode && handleActionPress}
       width="100%"
     />

--- a/src/components/FeatureFeed/Features/ChipListFeature.js
+++ b/src/components/FeatureFeed/Features/ChipListFeature.js
@@ -18,7 +18,7 @@ function ChipListFeature(props = {}) {
           ({ title, iconName, relatedNode }, index) => {
             if (index === 0) {
               return (
-                <Styled.Chip ml="xs" href={relatedNode.url}>
+                <Styled.Chip ml="xs" href={relatedNode.url} key={index}>
                   <ArrowUpRight size={20} weight="bold" color="#8E8E93" />
                   <span>{title}</span>
                 </Styled.Chip>
@@ -27,7 +27,7 @@ function ChipListFeature(props = {}) {
 
             if (index === props.feature?.chips.length - 1) {
               return (
-                <Styled.Chip mr="xs" href={relatedNode.url}>
+                <Styled.Chip mr="xs" href={relatedNode.url} key={index}>
                   <ArrowUpRight size={20} weight="bold" color="#8E8E93" />
                   <span>{title}</span>
                 </Styled.Chip>
@@ -35,7 +35,7 @@ function ChipListFeature(props = {}) {
             }
 
             return (
-              <Styled.Chip href={relatedNode.url}>
+              <Styled.Chip href={relatedNode.url} key={index}>
                 <ArrowUpRight size={20} weight="bold" color="#8E8E93" />
                 <span>{title}</span>
               </Styled.Chip>

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -11,11 +11,16 @@ import {
   set as setModal,
   useModal,
 } from '../../providers/ModalProvider';
+import {
+  reset as resetBreadcrumb,
+  useBreadcrumbDispatch,
+} from '../../providers/BreadcrumbProvider';
 import { X } from 'phosphor-react';
 
 const Modal = (props = {}) => {
   const [state, dispatch] = useModal();
   const [searchParams, setSearchParams] = useSearchParams();
+  const dispatchBreadcrumb = useBreadcrumbDispatch();
 
   useEffect(() => {
     // Watch for changes to the `id` search param
@@ -31,6 +36,7 @@ const Modal = (props = {}) => {
   function handleCloseModal() {
     dispatch(closeModal());
     setSearchParams('');
+    dispatchBreadcrumb(resetBreadcrumb());
   }
 
   return (

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -30,6 +30,7 @@ const Modal = (props = {}) => {
 
   function handleCloseModal() {
     dispatch(closeModal());
+    setSearchParams('');
   }
 
   return (

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -199,6 +199,30 @@ export default function Autocomplete({
   const searchState = useSearchState();
   const inputRef = useRef(null);
 
+  function setAriaSelectedToFalseOnHover(
+    parentClassName,
+    childClassName,
+    hoverElementClassName
+  ) {
+    const parentElement = document.querySelector(parentClassName);
+    const hoverElement = document.querySelector(hoverElementClassName);
+
+    if (autocompleteState.isOpen) {
+      if (!parentElement) {
+        return;
+      }
+      if (!hoverElement) {
+        return;
+      }
+      hoverElement.addEventListener('mouseover', function () {
+        const children = parentElement.querySelectorAll(childClassName);
+        for (let i = 0; i < children.length; i++) {
+          children[i].setAttribute('aria-selected', 'false');
+        }
+      });
+    }
+  }
+
   const clearInput = () => {
     const value = inputProps.value;
     if (value) {
@@ -344,6 +368,8 @@ export default function Autocomplete({
       }
     }
 
+    setAriaSelectedToFalseOnHover('.aa-List', '.aa-Item', '.empty-feed');
+
     document.addEventListener('click', handleClickOutside);
 
     return () => {
@@ -486,14 +512,16 @@ export default function Autocomplete({
             ) : null;
           })}
         {autocompleteState.isOpen && autocompleteState.query === '' ? (
-          <FeatureFeedProvider
-            Component={Feed}
-            options={{
-              variables: {
-                itemId: searchState.searchFeed,
-              },
-            }}
-          />
+          <Box className="empty-feed">
+            <FeatureFeedProvider
+              Component={Feed}
+              options={{
+                variables: {
+                  itemId: searchState.searchFeed,
+                },
+              }}
+            />
+          </Box>
         ) : null}
       </Box>
     </div>

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -204,21 +204,23 @@ export default function Autocomplete({
     childClassName,
     hoverElementClassName
   ) {
-    const parentElement = document.querySelector(parentClassName);
+    const parentElements = document.querySelectorAll(parentClassName);
     const hoverElement = document.querySelector(hoverElementClassName);
 
     if (autocompleteState.isOpen) {
-      if (!parentElement) {
+      if (parentElements.length === 0) {
         return;
       }
       if (!hoverElement) {
         return;
       }
       hoverElement.addEventListener('mouseover', function () {
-        const children = parentElement.querySelectorAll(childClassName);
-        for (let i = 0; i < children.length; i++) {
-          children[i].setAttribute('aria-selected', 'false');
-        }
+        parentElements.forEach(function (parentElement) {
+          const children = parentElement.querySelectorAll(childClassName);
+          for (let i = 0; i < children.length; i++) {
+            children[i].setAttribute('aria-selected', 'false');
+          }
+        });
       });
     }
   }

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -378,6 +378,19 @@ export default function Autocomplete({
         setShowTextPrompt(true);
       }
     }
+    function openDropdownMenu() {
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeDropdownMenu() {
+      document.body.style.overflow = '';
+    }
+
+    if (autocompleteState.isOpen && window.innerWidth < MOBILE_BREAKPOINT) {
+      openDropdownMenu();
+    } else {
+      closeDropdownMenu();
+    }
 
     setAriaSelectedToFalseOnHover('.aa-List', '.aa-Item', '.empty-feed');
 

--- a/src/components/Searchbar/Autocomplete.js
+++ b/src/components/Searchbar/Autocomplete.js
@@ -90,10 +90,7 @@ function QuerySuggestionItem({ item, autocomplete, handleActionPress }) {
           <MagnifyingGlass size={24} weight="bold" />
         </div>
         <div className="aa-ItemContentBody">
-          <div
-            className="aa-ItemContentTitle"
-            onClick={() => handleActionPress(item)}
-          >
+          <div className="aa-ItemContentTitle">
             <Hit hit={item} />
           </div>
         </div>
@@ -260,6 +257,18 @@ export default function Autocomplete({
   const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     searchClient,
     indexName: `ContentItem_${searchState.church}`,
+    transformSource({ source }) {
+      return {
+        ...source,
+        onSelect({ setQuery, item, setIsOpen, refresh, event }) {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsOpen(true);
+          setQuery(item.title);
+          refresh();
+        },
+      };
+    },
   });
 
   const autocomplete = useMemo(() => {

--- a/src/utils/parseDescriptionLinks.js
+++ b/src/utils/parseDescriptionLinks.js
@@ -1,15 +1,28 @@
-//Check if string contains links
+// //Check if string contains links
+import DOMPurify from 'dompurify';
 
 export default function parseDescription(description) {
-  const words = description.split(' ');
-  let result = '';
-  words.forEach((word) => {
-    //If "word" is actually a link, attach an <a> tag
-    if (word.match(/(https?:\/\/[^\s]+)/g)) {
-      result += `<a href=${word} target="_blank" rel="noopener noreferrer" style="color: blue; text-decoration: underline;">${word}</a> `;
-    } else {
-      result += `${word} `;
+  const sanitizedHTML = DOMPurify.sanitize(description);
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(sanitizedHTML, 'text/html');
+
+  const anchorTags = doc.getElementsByTagName('a');
+  for (let i = 0; i < anchorTags.length; i++) {
+    const anchorTag = anchorTags[i];
+    const href = anchorTag.getAttribute('href');
+    const target = anchorTag.getAttribute('target');
+    const rel = anchorTag.getAttribute('rel');
+
+    if (href) {
+      if (href.startsWith('http')) {
+        anchorTag.style.color = 'blue';
+        anchorTag.setAttribute('target', '_blank');
+        anchorTag.setAttribute('rel', 'noopener noreferrer');
+      }
+      anchorTag.style.textDecoration = 'underline';
     }
-  });
-  return result.trim();
+  }
+
+  return doc.body.innerHTML;
 }


### PR DESCRIPTION
## Notes

- All bug fixes here are related to functionality/UX, and are not related to/don't need changes in backend or admin.
- I will have separate PR for styling and the other functionality/UX todos
- Lots of scopes in this PR, added checklist if it helps
- Let me know if this PR fixes this basecamp scope as well, I've added some comments on the todo: [🐞 Breadcrumbs are not working correctly](https://3.basecamp.com/3926363/buckets/27088350/todos/6275249213)

##  Basecamp Scope Checklist

- [ ] [🐞 Fix html content to render correctly](https://3.basecamp.com/3926363/buckets/27088350/todos/6273589519)
- [ ] [🐞 Double "hover states" on empty search state](https://3.basecamp.com/3926363/buckets/27088350/todos/6260610264)
- [ ] [🐞 When clicking on algolia search suggestions anywhere it should just pre-fill the input](https://3.basecamp.com/3926363/buckets/27088350/todos/6278294538)
- [ ] [🐞 Clear search params on X of content single](https://3.basecamp.com/3926363/buckets/27088350/todos/6279047622)
- [ ] [🐞 Scroll not working correctly on mobile with search open](https://3.basecamp.com/3926363/buckets/27088350/todos/6279008683)
- [ ] [🐞 Breadcrumbs break when... 🧵](https://3.basecamp.com/3926363/buckets/27088350/todos/6279108662)

## What was done?
- **Basecamp fixes**
    - All things tracked on Basecamp are below with what was done
- **Non-Basecamp fixes**
    - Reset breadcrumb state when 'x'ing out of a modal (doesn't make sense that the breadcrumbs stack once closing out modal + removes duplicates)
    - Slight edit to ButtonFeature for when churches pass in a HTML button to render, which will have different prop structure, causing an error / rendering a button with no text.'
     **_EDIT:_** SCOPE HERE:[🐞 Blue div at the bottom of "Growth Track" view on Cedar Creek](https://3.basecamp.com/3926363/buckets/27088350/todos/6278212348)
   
<img width="400" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/447f5853-3850-4e26-b4e7-5190806dae1d">
<img width="400" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/420323ee-f9eb-4e5a-b50a-521207dfa2ee">




## 1. [🐞 Fix html content to render correctly](https://3.basecamp.com/3926363/buckets/27088350/todos/6273589519)

- Rewrote `parseDescriptionLinks` to previous parsing bug causing HTML content to render incorrectly

### Before:

<img width="300" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/82603c2c-a691-4225-b169-ca30c26c9d30">

<img width="300" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/0810dd22-ca4a-44a3-a717-750d5e5f8e39">

### After:

<img width="300" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/6a69edea-9fcc-4aa8-854c-f59877d0faa1">

## 2. [🐞 Double "hover states" on empty search state](https://3.basecamp.com/3926363/buckets/27088350/todos/6260610264)

 - Added `setAriaSelectedToFalseOnHover` function to remove double hover styles

https://github.com/ApollosProject/apollos-embeds/assets/68402088/26ff52d4-74c2-4280-8e34-98e75ae404d5


## 3. [🐞 When clicking on algolia search suggestions anywhere it should just pre-fill the input](https://3.basecamp.com/3926363/buckets/27088350/todos/6278294538)

 - Refactored `querySuggestionsPlugin`'s `onSelect` function to pre-fill input instead of redirecting
 - Removed `onClick` function on `ItemContentTitle`

https://github.com/ApollosProject/apollos-embeds/assets/68402088/bb5d653f-eece-438e-a6fd-7548dc20dce0


## 4. [🐞 Scroll not working correctly on mobile with search open](https://3.basecamp.com/3926363/buckets/27088350/todos/6279008683)

 - Added css styles to `body` that makes it unscrollable when dropdown is open on mobile, prevents scrolling content under the dropdown

## 5. [🐞 Breadcrumbs break when... 🧵](https://3.basecamp.com/3926363/buckets/27088350/todos/6279108662) &  [🐞 Clear search params on X of content single](https://3.basecamp.com/3926363/buckets/27088350/todos/6279047622)

 - Added `setSearchParams` to clear search params when closing out the modal
     - Doing this fixed the Breadcrumb bug of refreshing and the breadcrumb not showing up when clicking the same item after closing it out.

https://github.com/ApollosProject/apollos-embeds/assets/68402088/9d2344fe-1986-4911-9e8f-79ed31ec400e




