### PR TITLE
Church logo

### DIFF
--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -6,10 +6,15 @@ import Styled from './Logo.styles';
 
 import { Box, systemPropTypes } from '../../ui-kit';
 
-function Logo({ fill, size, theme, ...rest }) {
+function Logo({ fill, size, theme, source, ...rest }) {
   return (
     <Box {...rest}>
-      <Styled.Image src="./icon.png" alt="Logo" size={size} fill={fill} />
+      <Styled.Image
+        src={source || './icon.png'}
+        alt="Logo"
+        size={size}
+        fill={fill}
+      />
     </Box>
   );
 }
@@ -18,6 +23,7 @@ Logo.propTypes = {
   ...systemPropTypes,
   fill: PropTypes.string,
   size: PropTypes.number,
+  source: PropTypes.string,
 };
 
 export default withTheme(Logo);

--- a/src/components/Logo/Logo.styles.js
+++ b/src/components/Logo/Logo.styles.js
@@ -21,7 +21,6 @@ const imageStyles = ({ size, fill, theme }) => {
 
 const Image = withTheme(styled.img`
   resizemode: 'contain';
-
   ${imageStyles};
   ${system};
 `);

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -219,8 +219,12 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
                   borderRadius="xl"
                   mb="s"
                   mt={utils.rem('90px')}
+                  overflow="hidden"
+                  display="flex"
+                  justifyContent="center"
+                  alignItems="center"
                 >
-                  <Logo />
+                  <Logo source={currentChurch?.logo} />
                 </Box>
                 <H4 mb="xxs">{rest.adTitle || 'Stay Connected'}</H4>
                 <BodyText maxWidth="285px" textAlign="center" mb="l">

--- a/src/hooks/useCurrentChurch.js
+++ b/src/hooks/useCurrentChurch.js
@@ -8,6 +8,7 @@ export const GET_CURRENT_CHURCH = gql`
       name
       slug
       theme
+      logo
     }
   }
 `;


### PR DESCRIPTION
## Basecamp Scope

[🐞 Change the logo to the correct church logo dynamically](https://3.basecamp.com/3926363/buckets/27088350/todos/6259906908)

[🐞 Logo not working on Cedar Creek demo](https://3.basecamp.com/3926363/buckets/27088350/todos/6273532863)

## What was done?

1. Use current church's logo to render in profile menu
2. edit `Logo` component to accept a source, or default to apollos icon

_Cedar Creek logo below_

<img width="607" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/8bbdf6c5-f650-4776-8d0f-58cfe03f12be">

