### PR TITLE
Fix border-radius issue on search panel

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -427,7 +427,6 @@ export default function Autocomplete({
         className="aa-Panel"
         dropdown={autocompleteState.isOpen}
         {...autocomplete.getPanelProps({})}
-        borderRadius="0px 0px 15px 15px"
       >
         {autocompleteState.isOpen && <div id="panel-top"></div>}
         {autocompleteState.isOpen &&

--- a/packages/web-shared/components/Searchbar/Search.styles.js
+++ b/packages/web-shared/components/Searchbar/Search.styles.js
@@ -66,6 +66,7 @@ const Wrapper = withTheme(styled.div`
     transition: 0s;
     overflow-y: scroll;
     overflow-x: hidden;
+    border-radius: 0px 0px 15px 15px;
     ${showPanel}
   }
 


### PR DESCRIPTION
Before:
<img width="168" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/a4310487-cd36-4515-88e5-d64b1e1158c9">

After:
<img width="123" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/c38f934f-a085-4853-8bb0-880b4d4a9068">


Ignore the background on the "after", that is just a local change to see the border issue easier.
