### PR TITLE
Improve base breadcrumb to be driven by url

### DIFF
--- a/packages/web-shared/components/Breadcrumbs/Breadcrumbs.js
+++ b/packages/web-shared/components/Breadcrumbs/Breadcrumbs.js
@@ -22,12 +22,21 @@ function Breadcrumbs(props = {}) {
     setSearchParams(`${url}`);
   }
 
+  const pathname = window.location.pathname;
+  const dynamicRoute = /^\/[a-z0-9-]+$/i;
+
   return (
     <Box display="flex" alignItems="center" mb="xl">
       {state.length > 0 ? (
         <Button
           variant="link"
-          title={`Featured`}
+          title={
+            dynamicRoute.test(pathname)
+              ? `${pathname.slice(1).charAt(0).toUpperCase()}${pathname.slice(
+                  2
+                )}`
+              : 'Home'
+          }
           onClick={() => handleBreadClick({ id: -1, url: '' })}
         />
       ) : null}


### PR DESCRIPTION
Changes the root breadcrumb from just "Featured" to be dynamically driven by the url.

<img width="1097" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/62982645-1501-4105-97cc-8ce14cb1e675">
<img width="1035" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/d7f2a2f3-028d-4eb5-bafc-0f38b6ac650a">
