### PR TITLE
Web qa

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -1,17 +1,17 @@
-import React, { useEffect } from 'react';
-import PropTypes from 'prop-types';
-import format from 'date-fns/format';
-import addMinutes from 'date-fns/addMinutes';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
+import format from "date-fns/format";
+import addMinutes from "date-fns/addMinutes";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
-import { getURLFromType, parseDescriptionLinks } from '../utils';
-import FeatureFeed from './FeatureFeed';
-import FeatureFeedComponentMap from './FeatureFeed/FeatureFeedComponentMap';
+import { getURLFromType, parseDescriptionLinks } from "../utils";
+import FeatureFeed from "./FeatureFeed";
+import FeatureFeedComponentMap from "./FeatureFeed/FeatureFeedComponentMap";
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from '../providers/BreadcrumbProvider';
-import { set as setModal, useModal } from '../providers/ModalProvider';
+} from "../providers/BreadcrumbProvider";
+import { set as setModal, useModal } from "../providers/ModalProvider";
 
 import {
   Box,
@@ -24,10 +24,10 @@ import {
   MediaItem,
   BodyText,
   ShareButton,
-} from '../ui-kit';
-import { useVideoMediaProgress } from '../hooks';
-import VideoPlayer from './VideoPlayer';
-import InteractWhenLoaded from './InteractWhenLoaded';
+} from "../ui-kit";
+import { useVideoMediaProgress } from "../hooks";
+import VideoPlayer from "./VideoPlayer";
+import InteractWhenLoaded from "./InteractWhenLoaded";
 
 function ContentSingle(props = {}) {
   const navigate = useNavigate();
@@ -50,7 +50,7 @@ function ContentSingle(props = {}) {
   useEffect(() => {
     if (!state.modal && invalidPage) {
       navigate({
-        pathname: '/',
+        pathname: "/",
       });
     }
   }, [invalidPage, navigate]);
@@ -92,7 +92,7 @@ function ContentSingle(props = {}) {
   const formattedPublishDate = props?.data?.publishDate
     ? format(
         addMinutes(publishDate, publishDate.getTimezoneOffset()),
-        'MMMM do, yyyy'
+        "MMMM do, yyyy"
       )
     : null;
 
@@ -104,7 +104,7 @@ function ContentSingle(props = {}) {
   );
 
   const handleActionPress = (item) => {
-    if (searchParams.get('id') !== getURLFromType(item)) {
+    if (searchParams.get("id") !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item)}`,
@@ -125,7 +125,7 @@ function ContentSingle(props = {}) {
         <InteractWhenLoaded
           loading={props.loading}
           nodeId={props.data.id}
-          action={'VIEW'}
+          action={"VIEW"}
         />
         <Box mb="base" borderRadius="xl" overflow="hidden">
           {props.data?.videos[0] ? (
@@ -148,13 +148,13 @@ function ContentSingle(props = {}) {
           <Box
             display="flex"
             flexDirection={{
-              _: 'column',
-              md: 'row',
+              _: "column",
+              md: "row",
             }}
             justifyContent="space-between"
             alignItems={{
-              _: 'start',
-              md: 'center',
+              _: "start",
+              md: "center",
             }}
             mb="s"
           >
@@ -166,7 +166,7 @@ function ContentSingle(props = {}) {
                 {parentChannel.name ? (
                   <BodyText
                     color="text.secondary"
-                    mb={title && !hasChildContent ? 'xxs' : ''}
+                    mb={title && !hasChildContent ? "xxs" : ""}
                   >
                     {parentChannel.name}
                   </BodyText>
@@ -183,8 +183,8 @@ function ContentSingle(props = {}) {
             </Box>
             <Box
               mt={{
-                _: 'xs',
-                md: '0',
+                _: "xs",
+                md: "0",
               }}
             >
               <ShareButton contentTitle={title} />
@@ -194,8 +194,8 @@ function ContentSingle(props = {}) {
           {/* Children Count */}
           {showEpisodeCount ? (
             <H4 color="text.secondary" mr="l">
-              {childContentItems.length}{' '}
-              {`Episode${childContentItems.length === 1 ? '' : 's'}`}
+              {childContentItems.length}{" "}
+              {`Episode${childContentItems.length === 1 ? "" : "s"}`}
             </H4>
           ) : null}
           {htmlContent ? (
@@ -217,13 +217,13 @@ function ContentSingle(props = {}) {
               display="grid"
               gridGap="30px"
               gridTemplateColumns={{
-                _: 'repeat(1, minmax(0, 1fr));',
-                md: 'repeat(2, minmax(0, 1fr));',
-                lg: 'repeat(3, minmax(0, 1fr));',
+                _: "repeat(1, minmax(0, 1fr));",
+                md: "repeat(2, minmax(0, 1fr));",
+                lg: "repeat(3, minmax(0, 1fr));",
               }}
               padding={{
-                _: '30px',
-                md: '0',
+                _: "30px",
+                md: "0",
               }}
             >
               {childContentItems?.map((item, index) => (
@@ -247,13 +247,13 @@ function ContentSingle(props = {}) {
               display="grid"
               gridGap="30px"
               gridTemplateColumns={{
-                _: 'repeat(1, minmax(0, 1fr));',
-                md: 'repeat(2, minmax(0, 1fr));',
-                lg: 'repeat(3, minmax(0, 1fr));',
+                _: "repeat(1, minmax(0, 1fr));",
+                md: "repeat(2, minmax(0, 1fr));",
+                lg: "repeat(3, minmax(0, 1fr));",
               }}
               padding={{
-                _: '30px',
-                md: '0',
+                _: "30px",
+                md: "0",
               }}
             >
               {siblingContentItems?.map((item, index) => (

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import get from 'lodash/get';
-import { useSearchParams } from 'react-router-dom';
+import React from "react";
+import get from "lodash/get";
+import { useSearchParams } from "react-router-dom";
 
-import { getURLFromType } from '../../../utils';
+import { getURLFromType } from "../../../utils";
 import {
   ContentCard,
   Box,
@@ -10,19 +10,19 @@ import {
   systemPropTypes,
   Button,
   ButtonGroup,
-} from '../../../ui-kit';
+} from "../../../ui-kit";
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from '../../../providers/BreadcrumbProvider';
+} from "../../../providers/BreadcrumbProvider";
 import {
   open as openModal,
   set as setModal,
   useModal,
-} from '../../../providers/ModalProvider';
-import { CaretRight } from 'phosphor-react';
+} from "../../../providers/ModalProvider";
+import { CaretRight } from "phosphor-react";
 
-import Carousel from 'react-multi-carousel';
+import Carousel from "react-multi-carousel";
 
 const SHOW_VIEW_ALL_LIMIT = 5;
 
@@ -50,7 +50,7 @@ function HorizontalCardListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (searchParams.get('id') !== getURLFromType(item.relatedNode)) {
+    if (searchParams.get("id") !== getURLFromType(item.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item.relatedNode)}`,
@@ -68,7 +68,7 @@ function HorizontalCardListFeature(props = {}) {
 
   const handlePrimaryActionPress = () => {
     if (
-      searchParams.get('id') !==
+      searchParams.get("id") !==
       getURLFromType(props?.feature?.primaryAction.relatedNode)
     ) {
       dispatchBreadcrumb(
@@ -80,7 +80,10 @@ function HorizontalCardListFeature(props = {}) {
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      setSearchParams({ id, action: 'viewall' });
+      setSearchParams({ id, action: "viewall" });
+    }
+    if (state.modal) {
+      dispatch(openModal());
     }
   };
 
@@ -123,7 +126,7 @@ function HorizontalCardListFeature(props = {}) {
               title={item.title}
               summary={item.summary}
               onClick={() => handleActionPress(item)}
-              videoMedia={get(item, 'relatedNode?.videos[0]', null)}
+              videoMedia={get(item, "relatedNode?.videos[0]", null)}
             />
           ))}
         </Carousel>
@@ -136,7 +139,7 @@ function HorizontalCardListFeature(props = {}) {
           px="l"
           textAlign="center"
         >
-          {props.feature.title === 'Continue Watching' ? (
+          {props.feature.title === "Continue Watching" ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!
             </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import get from 'lodash/get';
-import { useSearchParams } from 'react-router-dom';
+import React from "react";
+import get from "lodash/get";
+import { useSearchParams } from "react-router-dom";
 
-import { getURLFromType } from '../../../utils';
+import { getURLFromType } from "../../../utils";
 import {
   Box,
   H3,
@@ -10,19 +10,19 @@ import {
   Button,
   MediaItem,
   ButtonGroup,
-} from '../../../ui-kit';
+} from "../../../ui-kit";
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from '../../../providers/BreadcrumbProvider';
+} from "../../../providers/BreadcrumbProvider";
 import {
   open as openModal,
   set as setModal,
   useModal,
-} from '../../../providers/ModalProvider';
+} from "../../../providers/ModalProvider";
 
-import Carousel from 'react-multi-carousel';
-import { CaretRight } from 'phosphor-react';
+import Carousel from "react-multi-carousel";
+import { CaretRight } from "phosphor-react";
 const SHOW_VIEW_ALL_LIMIT = 5;
 
 const responsive = {
@@ -49,7 +49,7 @@ function HorizontalMediaListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (searchParams.get('id') !== getURLFromType(item.relatedNode)) {
+    if (searchParams.get("id") !== getURLFromType(item.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item.relatedNode)}`,
@@ -67,7 +67,7 @@ function HorizontalMediaListFeature(props = {}) {
 
   const handlePrimaryActionPress = () => {
     if (
-      searchParams.get('id') !==
+      searchParams.get("id") !==
       getURLFromType(props?.feature?.primaryAction.relatedNode)
     ) {
       dispatchBreadcrumb(
@@ -79,7 +79,10 @@ function HorizontalMediaListFeature(props = {}) {
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      setSearchParams({ id, action: 'viewall' });
+      setSearchParams({ id, action: "viewall" });
+    }
+    if (state.modal) {
+      dispatch(openModal());
     }
   };
 
@@ -124,7 +127,7 @@ function HorizontalMediaListFeature(props = {}) {
                 title={item.title}
                 summary={item.summary}
                 onClick={() => handleActionPress(item)}
-                videoMedia={get(item, 'relatedNode?.videos[0]', null)}
+                videoMedia={get(item, "relatedNode?.videos[0]", null)}
               />
             );
           })}
@@ -138,7 +141,7 @@ function HorizontalMediaListFeature(props = {}) {
           px="l"
           textAlign="center"
         >
-          {props.feature.title === 'Continue Watching' ? (
+          {props.feature.title === "Continue Watching" ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!
             </Box>

--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -1,21 +1,21 @@
-import React, { useEffect } from 'react';
-import { systemPropTypes } from '../../ui-kit/_lib/system';
-import Styled from './Modal.styles';
-import { Box } from '../../ui-kit';
-import { Searchbar } from '../../components';
-import Breadcrumbs from '../Breadcrumbs';
-import { useSearchParams } from 'react-router-dom';
+import React, { useEffect, useState } from "react";
+import { systemPropTypes } from "../../ui-kit/_lib/system";
+import Styled from "./Modal.styles";
+import { Box } from "../../ui-kit";
+import { Searchbar } from "../../components";
+import Breadcrumbs from "../Breadcrumbs";
+import { useSearchParams } from "react-router-dom";
 import {
   open as openModal,
   close as closeModal,
   set as setModal,
   useModal,
-} from '../../providers/ModalProvider';
+} from "../../providers/ModalProvider";
 import {
   reset as resetBreadcrumb,
   useBreadcrumbDispatch,
-} from '../../providers/BreadcrumbProvider';
-import { X } from 'phosphor-react';
+} from "../../providers/BreadcrumbProvider";
+import { X } from "phosphor-react";
 
 const Modal = (props = {}) => {
   const [state, dispatch] = useModal();
@@ -24,76 +24,80 @@ const Modal = (props = {}) => {
 
   useEffect(() => {
     // Watch for changes to the `id` search param
-    if (searchParams.get('id')) {
-      dispatch(openModal());
-      dispatch(setModal(searchParams.get('id')));
+    if (searchParams.get("id")) {
+      // dispatch(openModal());
+      dispatch(setModal(searchParams.get("id")));
     }
-    if (searchParams.get('id') === null) {
+    if (searchParams.get("id") === null) {
       dispatch(closeModal());
     }
   }, [dispatch, searchParams]);
 
   function handleCloseModal() {
     dispatch(closeModal());
-    setSearchParams('');
+    setSearchParams("");
     dispatchBreadcrumb(resetBreadcrumb());
   }
 
+  console.log(searchParams.get("id"));
+
   return (
     <Box>
-      {state.isOpen ? (
-        <Styled.Modal>
-          <Styled.ModalContainer>
-            <Box
-              width="100%"
-              display="flex"
-              mb="s"
-              alignItems="center"
-              justifyContent="space-between"
-              flexDirection={{ _: 'column-reverse', sm: 'row' }}
-            >
-              <Box width={{ _: '0', sm: '10%' }}></Box>
+      <Styled.Modal show={state.isOpen}>
+        <Styled.ModalContainer>
+          {state.content ? (
+            <>
+              <Box
+                width="100%"
+                display="flex"
+                mb="s"
+                alignItems="center"
+                justifyContent="space-between"
+                flexDirection={{ _: "column-reverse", sm: "row" }}
+              >
+                <Box width={{ _: "0", sm: "10%" }}></Box>
+                <Box
+                  width={{
+                    _: "100%",
+                    md: "700px",
+                    lg: "900px",
+                  }}
+                  mx="auto"
+                  justifyContent="center"
+                  alignItems="center"
+                >
+                  <Searchbar width="100%" />
+                </Box>
+                <Box
+                  width={{ _: "100%", sm: "10%" }}
+                  mb={{ _: "xs", sm: "0" }}
+                  ml={{ _: "0", sm: "xs" }}
+                  display="flex"
+                  justifyContent="flex-end"
+                  alignItems="center"
+                >
+                  <Styled.Icon
+                    onClick={handleCloseModal}
+                    ml={{ _: "auto", sm: "0" }}
+                  >
+                    <X size={16} weight="bold" />
+                  </Styled.Icon>
+                </Box>
+              </Box>
+              <Breadcrumbs />
               <Box
                 width={{
-                  _: '100%',
-                  md: '700px',
-                  lg: '900px',
+                  _: "100%",
+                  md: "750px",
+                  lg: "1180px",
                 }}
-                mx="auto"
-                justifyContent="center"
-                alignItems="center"
               >
-                <Searchbar width="100%" />
+                {state.content}
               </Box>
-              <Box
-                width={{ _: '100%', sm: '10%' }}
-                mb={{ _: 'xs', sm: '0' }}
-                ml={{ _: '0', sm: 'xs' }}
-                display="flex"
-                justifyContent="flex-end"
-                alignItems="center"
-              >
-                <Styled.Icon
-                  onClick={handleCloseModal}
-                  ml={{ _: 'auto', sm: '0' }}
-                >
-                  <X size={16} weight="bold" />
-                </Styled.Icon>
-              </Box>
-            </Box>
-            <Breadcrumbs />
-            <Box
-              width={{
-                _: '100%',
-                md: '750px',
-                lg: '1180px',
-              }}
-            >
-              {state.content}
-            </Box>
-          </Styled.ModalContainer>
-        </Styled.Modal>
-      ) : null}
+            </>
+          ) : null}
+        </Styled.ModalContainer>
+      </Styled.Modal>
     </Box>
   );
 };

--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -25,7 +25,7 @@ const Modal = (props = {}) => {
   useEffect(() => {
     // Watch for changes to the `id` search param
     if (searchParams.get("id")) {
-      // dispatch(openModal());
+      dispatch(openModal());
       dispatch(setModal(searchParams.get("id")));
     }
     if (searchParams.get("id") === null) {

--- a/packages/web-shared/components/Modal/Modal.styles.js
+++ b/packages/web-shared/components/Modal/Modal.styles.js
@@ -1,8 +1,27 @@
-import { withTheme } from 'styled-components';
-import styled, { css } from 'styled-components';
-import { themeGet } from '@styled-system/theme-get';
+import { withTheme } from "styled-components";
+import styled, { css, keyframes } from "styled-components";
+import { themeGet } from "@styled-system/theme-get";
 
-import { system } from '../../ui-kit/_lib/system';
+import { system } from "../../ui-kit/_lib/system";
+
+const slideIn = keyframes`
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+`;
+
+// Define a keyframe animation for sliding out
+const slideOut = keyframes`
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+`;
 
 const Modal = withTheme(styled.div`
   width: 100vw;
@@ -16,7 +35,8 @@ const Modal = withTheme(styled.div`
   justify-content: center;
   align-items: center;
   z-index: 9999;
-  transition: opacity 0.3s ease;
+  animation: ${(props) => (props.show ? slideIn : slideOut)} 0.3s ease-in-out;
+  transform: translateY(${(props) => (props.show ? "0" : "100%")});
   ${system};
 `);
 
@@ -29,7 +49,7 @@ const ModalContainer = withTheme(styled.div`
   background-color: #ffffff;
   overflow-y: scroll;
   padding: 40px;
-  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+  @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
     padding: 16px;
   }
   ${system};
@@ -49,7 +69,7 @@ const Icon = withTheme(styled.div`
   width: 32px;
 
   &:hover {
-    color: ${themeGet('colors.base.secondary')};
+    color: ${themeGet("colors.base.secondary")};
     cursor: pointer;
   }
   ${system};

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -404,7 +404,6 @@ export default function Autocomplete({
     };
   }, [autocompleteState.isOpen, autocomplete, setShowTextPrompt]);
 
-  console.log(autocompleteState.collections);
   const searchResults = [];
   const pluginResults = [];
 
@@ -421,8 +420,6 @@ export default function Autocomplete({
 
   const orderedSearchResults = [searchResults[1], searchResults[0]];
 
-  console.log("searchResults", searchResults);
-  console.log("pluginResults", pluginResults);
   // ...CUSTOM RENDERER
   return (
     <div className="aa-Autocomplete" {...containerProps}>

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -4,43 +4,43 @@ import React, {
   useMemo,
   createElement,
   Fragment,
-} from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
+} from "react";
+import { useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   ClockCounterClockwise,
   MagnifyingGlass,
   CaretDown,
   CaretRight,
   X,
-} from 'phosphor-react';
+} from "phosphor-react";
 
-import algoliasearch from 'algoliasearch/lite';
-import { createAutocomplete } from '@algolia/autocomplete-core';
+import algoliasearch from "algoliasearch/lite";
+import { createAutocomplete } from "@algolia/autocomplete-core";
 import {
   getAlgoliaResults,
   parseAlgoliaHitHighlight,
-} from '@algolia/autocomplete-preset-algolia';
-import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
-import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import '@algolia/autocomplete-theme-classic';
+} from "@algolia/autocomplete-preset-algolia";
+import { createQuerySuggestionsPlugin } from "@algolia/autocomplete-plugin-query-suggestions";
+import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches";
+import "@algolia/autocomplete-theme-classic";
 
-import { FeatureFeedProvider } from '../../providers';
-import Feed from '../FeatureFeed';
-import { ResourceCard, Box } from '../../ui-kit';
+import { FeatureFeedProvider } from "../../providers";
+import Feed from "../FeatureFeed";
+import { ResourceCard, Box } from "../../ui-kit";
 
-import { useSearchState } from '../../providers/SearchProvider';
-import { getURLFromType } from '../../utils';
-import Styled from './Search.styles';
+import { useSearchState } from "../../providers/SearchProvider";
+import { getURLFromType } from "../../utils";
+import Styled from "./Search.styles";
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from '../../providers/BreadcrumbProvider';
+} from "../../providers/BreadcrumbProvider";
 import {
   open as openModal,
   set as setModal,
   useModal,
-} from '../../providers/ModalProvider';
+} from "../../providers/ModalProvider";
 
 const MOBILE_BREAKPOINT = 428;
 const appId = process.env.REACT_APP_ALGOLIA_APP_ID;
@@ -52,7 +52,7 @@ function Hit({ hit }) {
 }
 
 // Highlight text render
-function Highlight({ hit, attribute, tagName = 'mark' }) {
+function Highlight({ hit, attribute, tagName = "mark" }) {
   return createElement(
     Fragment,
     {},
@@ -70,7 +70,7 @@ function Highlight({ hit, attribute, tagName = 'mark' }) {
 
 // Recent Searches Index Definition
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
-  key: 'navbar',
+  key: "navbar",
   transformSource({ source }) {
     return {
       ...source,
@@ -177,7 +177,7 @@ export default function Autocomplete({
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (searchParams.get('id') !== getURLFromType(item)) {
+    if (searchParams.get("id") !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item)}`,
@@ -214,11 +214,11 @@ export default function Autocomplete({
       if (!hoverElement) {
         return;
       }
-      hoverElement.addEventListener('mouseover', function () {
+      hoverElement.addEventListener("mouseover", function () {
         parentElements.forEach(function (parentElement) {
           const children = parentElement.querySelectorAll(childClassName);
           for (let i = 0; i < children.length; i++) {
-            children[i].setAttribute('aria-selected', 'false');
+            children[i].setAttribute("aria-selected", "false");
           }
         });
       });
@@ -234,7 +234,7 @@ export default function Autocomplete({
         _highLightResult: { label: { value: value } },
       });
     }
-    autocomplete.setQuery('');
+    autocomplete.setQuery("");
     autocomplete.refresh();
   };
 
@@ -244,15 +244,15 @@ export default function Autocomplete({
     setAutocompleteState(updatedAutocompleteState);
 
     autocomplete.setIsOpen(!autocompleteState.isOpen);
-    inputRef.current?.[autocompleteState.isOpen ? 'blur' : 'focus']();
+    inputRef.current?.[autocompleteState.isOpen ? "blur" : "focus"]();
   };
 
   // (Desktop Specific Behavior): Hitting enter scrolls dropdown to results
   const scrollToResults = (event) => {
-    const resultsElement = document.getElementById('results');
+    const resultsElement = document.getElementById("results");
     event.preventDefault();
     if (resultsElement) {
-      resultsElement.scrollIntoView({ behavior: 'smooth' });
+      resultsElement.scrollIntoView({ behavior: "smooth" });
     }
   };
 
@@ -283,13 +283,13 @@ export default function Autocomplete({
         const panelElement =
           window.innerWidth < MOBILE_BREAKPOINT &&
           state.query !== props.prevState.query
-            ? document.getElementById('panel-top')
+            ? document.getElementById("panel-top")
             : null;
 
         if (panelElement) {
           panelElement.scrollIntoView({
-            behavior: 'instant',
-            block: 'start',
+            behavior: "instant",
+            block: "start",
           });
         }
         // (2) Synchronize the Autocomplete state with the React state.
@@ -299,7 +299,7 @@ export default function Autocomplete({
         return [
           // (3) Use an Algolia index source.
           {
-            sourceId: 'content',
+            sourceId: "content",
             getItemInputValue({ item }) {
               return item.query;
             },
@@ -325,7 +325,7 @@ export default function Autocomplete({
             },
           },
           {
-            sourceId: 'pages',
+            sourceId: "pages",
             getItemInputValue({ item }) {
               return item.query;
             },
@@ -356,8 +356,8 @@ export default function Autocomplete({
     });
   }, []);
 
-  const autoCompleteLabel = 'autocomplete-1-label';
-  const autoCompleteId = 'autocomplete-1-input';
+  const autoCompleteLabel = "autocomplete-1-label";
+  const autoCompleteId = "autocomplete-1-input";
 
   // Makes SSR consistent on aria aspects
   const containerProps = autocomplete.getRootProps({});
@@ -369,24 +369,24 @@ export default function Autocomplete({
 
   inputProps.id = autoCompleteId;
   formProps.onSubmit = scrollToResults;
-  containerProps['aria-labelledby'] = autoCompleteLabel;
-  inputProps['aria-labelledby'] = autoCompleteLabel;
-  panelProps['aria-labelledby'] = autoCompleteLabel;
+  containerProps["aria-labelledby"] = autoCompleteLabel;
+  inputProps["aria-labelledby"] = autoCompleteLabel;
+  panelProps["aria-labelledby"] = autoCompleteLabel;
 
   useEffect(() => {
     function handleClickOutside(event) {
-      if (autocompleteState.isOpen && !event.target.closest('#search')) {
+      if (autocompleteState.isOpen && !event.target.closest("#search")) {
         autocomplete.setIsOpen(false);
-        autocomplete.setQuery('');
+        autocomplete.setQuery("");
         setShowTextPrompt(true);
       }
     }
     function openDropdownMenu() {
-      document.body.style.overflow = 'hidden';
+      document.body.style.overflow = "hidden";
     }
 
     function closeDropdownMenu() {
-      document.body.style.overflow = '';
+      document.body.style.overflow = "";
     }
 
     if (autocompleteState.isOpen && window.innerWidth < MOBILE_BREAKPOINT) {
@@ -395,21 +395,40 @@ export default function Autocomplete({
       closeDropdownMenu();
     }
 
-    setAriaSelectedToFalseOnHover('.aa-List', '.aa-Item', '.empty-feed');
+    setAriaSelectedToFalseOnHover(".aa-List", ".aa-Item", ".empty-feed");
 
-    document.addEventListener('click', handleClickOutside);
+    document.addEventListener("click", handleClickOutside);
 
     return () => {
-      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener("click", handleClickOutside);
     };
   }, [autocompleteState.isOpen, autocomplete, setShowTextPrompt]);
 
+  console.log(autocompleteState.collections);
+  const searchResults = [];
+  const pluginResults = [];
+
+  // Loop through the array of objects and separate them based on id
+  autocompleteState.collections.forEach((item) => {
+    const { source } = item;
+
+    if (source.sourceId === "pages" || source.sourceId === "content") {
+      searchResults.push(item);
+    } else {
+      pluginResults.push(item);
+    }
+  });
+
+  const orderedSearchResults = [searchResults[1], searchResults[0]];
+
+  console.log("searchResults", searchResults);
+  console.log("pluginResults", pluginResults);
   // ...CUSTOM RENDERER
   return (
     <div className="aa-Autocomplete" {...containerProps}>
       <form className="aa-Form" {...formProps}>
         <input ref={inputRef} className="aa-Input" {...inputProps} />
-        {inputProps.value !== '' ? (
+        {inputProps.value !== "" ? (
           <div className="aa-ClearButton" onClick={clearInput}>
             <Styled.IconWrapper>
               <X size={18} weight="fill" />
@@ -430,11 +449,11 @@ export default function Autocomplete({
       >
         {autocompleteState.isOpen && <div id="panel-top"></div>}
         {autocompleteState.isOpen &&
-          autocompleteState.collections.map((collection, index) => {
+          pluginResults.map((collection, index) => {
             const { source, items } = collection;
             // Rendering of Query Suggestions
             if (
-              ['querySuggestionsPlugin', 'recentSearchesPlugin'].includes(
+              ["querySuggestionsPlugin", "recentSearchesPlugin"].includes(
                 collection.source.sourceId
               )
             ) {
@@ -453,7 +472,7 @@ export default function Autocomplete({
                         })}
                       >
                         {collection.source.sourceId ===
-                          'querySuggestionsPlugin' && (
+                          "querySuggestionsPlugin" && (
                           <QuerySuggestionItem
                             item={item}
                             autocomplete={autocomplete}
@@ -465,7 +484,7 @@ export default function Autocomplete({
                           />
                         )}
                         {collection.source.sourceId ===
-                          'recentSearchesPlugin' && (
+                          "recentSearchesPlugin" && (
                           <PastQueryItem
                             item={item}
                             autocomplete={autocomplete}
@@ -481,11 +500,15 @@ export default function Autocomplete({
                 </div>
               );
             }
+          })}
 
+        {autocompleteState.isOpen &&
+          orderedSearchResults.map((collection, index) => {
+            const { source, items } = collection;
             // Rendering of regular items
-            return autocompleteState.query !== '' ? (
+            return autocompleteState.query !== "" ? (
               <div key={`source-${index}`} className="aa-Source">
-                {collection.source.sourceId === 'content' && (
+                {collection.source.sourceId === "content" && (
                   <Box
                     padding="xs"
                     fontWeight="600"
@@ -495,7 +518,7 @@ export default function Autocomplete({
                     Content
                   </Box>
                 )}
-                {collection.source.sourceId === 'pages' && (
+                {collection.source.sourceId === "pages" && (
                   <Box padding="xs" fontWeight="600" color="base.gray">
                     Pages
                   </Box>
@@ -518,7 +541,7 @@ export default function Autocomplete({
                           leadingAsset={item?.coverImage}
                           title={item?.title}
                           onClick={() => {
-                            if (collection.source.sourceId === 'pages') {
+                            if (collection.source.sourceId === "pages") {
                               return handleStaticActionPress(item);
                             }
                             return handleActionPress(item);
@@ -543,7 +566,7 @@ export default function Autocomplete({
             ) : null;
           })}
         {autocompleteState.isOpen &&
-        autocompleteState.query === '' &&
+        autocompleteState.query === "" &&
         searchState.searchFeed ? (
           <Box className="empty-feed">
             <FeatureFeedProvider

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -299,7 +299,7 @@ export default function Autocomplete({
         return [
           // (3) Use an Algolia index source.
           {
-            sourceId: "content",
+            sourceId: "pages",
             getItemInputValue({ item }) {
               return item.query;
             },
@@ -308,9 +308,10 @@ export default function Autocomplete({
                 searchClient,
                 queries: [
                   {
-                    indexName: `ContentItem_${searchState.church}`,
+                    indexName: `WebPages_Global`,
                     query,
                     params: {
+                      facetFilters: [`church:${searchState.church}`],
                       hitsPerPage: 4,
                       clickAnalytics: true,
                       // highlightPreTag: '<mark>',
@@ -325,7 +326,7 @@ export default function Autocomplete({
             },
           },
           {
-            sourceId: "pages",
+            sourceId: "content",
             getItemInputValue({ item }) {
               return item.query;
             },
@@ -334,10 +335,9 @@ export default function Autocomplete({
                 searchClient,
                 queries: [
                   {
-                    indexName: `WebPages_Global`,
+                    indexName: `ContentItem_${searchState.church}`,
                     query,
                     params: {
-                      facetFilters: [`church:${searchState.church}`],
                       hitsPerPage: 4,
                       clickAnalytics: true,
                       // highlightPreTag: '<mark>',
@@ -404,22 +404,6 @@ export default function Autocomplete({
     };
   }, [autocompleteState.isOpen, autocomplete, setShowTextPrompt]);
 
-  const searchResults = [];
-  const pluginResults = [];
-
-  // Loop through the array of objects and separate them based on id
-  autocompleteState.collections.forEach((item) => {
-    const { source } = item;
-
-    if (source.sourceId === "pages" || source.sourceId === "content") {
-      searchResults.push(item);
-    } else {
-      pluginResults.push(item);
-    }
-  });
-
-  const orderedSearchResults = [searchResults[1], searchResults[0]];
-
   // ...CUSTOM RENDERER
   return (
     <div className="aa-Autocomplete" {...containerProps}>
@@ -446,7 +430,7 @@ export default function Autocomplete({
       >
         {autocompleteState.isOpen && <div id="panel-top"></div>}
         {autocompleteState.isOpen &&
-          pluginResults.map((collection, index) => {
+          autocompleteState.collections.map((collection, index) => {
             const { source, items } = collection;
             // Rendering of Query Suggestions
             if (
@@ -497,11 +481,7 @@ export default function Autocomplete({
                 </div>
               );
             }
-          })}
 
-        {autocompleteState.isOpen &&
-          orderedSearchResults.map((collection, index) => {
-            const { source, items } = collection;
             // Rendering of regular items
             return autocompleteState.query !== "" ? (
               <div key={`source-${index}`} className="aa-Source">

--- a/packages/web-shared/components/Searchbar/Search.styles.js
+++ b/packages/web-shared/components/Searchbar/Search.styles.js
@@ -1,27 +1,28 @@
-import { withTheme } from 'styled-components';
-import styled, { css } from 'styled-components';
-import { themeGet } from '@styled-system/theme-get';
+import { withTheme } from "styled-components";
+import styled, { css } from "styled-components";
+import { themeGet } from "@styled-system/theme-get";
 
-import { H4, TypeStyles } from '../../ui-kit/Typography';
-import { utils } from '../../ui-kit';
-import { system } from '../../ui-kit/_lib/system';
+import { H4, TypeStyles } from "../../ui-kit/Typography";
+import { utils } from "../../ui-kit";
+import { system } from "../../ui-kit/_lib/system";
 
 const showDropdown = ({ dropdown }) => {
   if (dropdown) {
     return css`
-      border-radius: ${themeGet('radii.xxl')} ${themeGet('radii.xxl')} 0px 0px;
-      @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+      border-radius: ${themeGet("radii.xxl")} ${themeGet("radii.xxl")} 0px 0px;
+      @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
         border-radius: 0px;
         position: fixed;
         bottom: 0;
         top: 0;
         right: 0;
         left: 0;
+        z-index: 1000;
       }
     `;
   } else {
     return css`
-      border-radius: ${themeGet('radii.xxl')};
+      border-radius: ${themeGet("radii.xxl")};
     `;
   }
 };
@@ -29,11 +30,12 @@ const showDropdown = ({ dropdown }) => {
 const showPanel = ({ dropdown }) => {
   if (dropdown) {
     return css`
-      @media screen and (min-width: ${themeGet('breakpoints.sm')}) {
+      @media screen and (min-width: ${themeGet("breakpoints.sm")}) {
         height: 600px;
       }
-      @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+      @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
         height: 100vh;
+        z-index: 1000;
       }
     `;
   } else {
@@ -45,8 +47,8 @@ const showPanel = ({ dropdown }) => {
 
 const Wrapper = withTheme(styled.div`
   align-items: center;
-  background: ${themeGet('colors.base.white')};
-  box-shadow: ${themeGet('shadows.medium')};
+  background: ${themeGet("colors.base.white")};
+  box-shadow: ${themeGet("shadows.medium")};
   display: flex;
   height: 60px;
   justify-content: space-between;
@@ -61,8 +63,8 @@ const Wrapper = withTheme(styled.div`
   .aa-Panel {
     width: 100%;
     left: 0;
-    background: ${themeGet('colors.base.white')};
-    box-shadow: ${themeGet('shadows.mediumBottom')};
+    background: ${themeGet("colors.base.white")};
+    box-shadow: ${themeGet("shadows.mediumBottom")};
     transition: 0s;
     overflow-y: scroll;
     overflow-x: hidden;
@@ -91,11 +93,11 @@ const TextPrompt = withTheme(styled.div`
   white-space: nowrap;
   width: 100%;
 
-  @media screen and (max-width: ${themeGet('breakpoints.md')}) {
+  @media screen and (max-width: ${themeGet("breakpoints.md")}) {
     max-width: 50%;
   }
 
-  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
+  @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
     max-width: 47%;
   }
 
@@ -148,22 +150,22 @@ const Input = withTheme(styled.input`
 const X = withTheme(styled.div`
   color: #27272e54;
   &:hover {
-    color: ${themeGet('colors.base.secondary')};
+    color: ${themeGet("colors.base.secondary")};
     cursor: pointer;
   }
   ${system}
 `);
 
 const Title = withTheme(styled(H4)`
-  font-size: ${utils.rem('16px')};
-  color: ${themeGet('colors.text.secondary')};
+  font-size: ${utils.rem("16px")};
+  color: ${themeGet("colors.text.secondary")};
 `);
 
 const IconWrapper = withTheme(styled.div`
   color: #27272e54;
   transition: 0.2s;
   &:hover {
-    color: ${themeGet('colors.base.secondary')};
+    color: ${themeGet("colors.base.secondary")};
     cursor: pointer;
   }
   ${system}


### PR DESCRIPTION
### Basecamp Scope:

[(Web) Search Embeds has a z-index issue with the church logo](https://3.basecamp.com/3926363/buckets/27088350/todos/6423916882/)

[(Web) Search Embed put Pages above Content on results](https://3.basecamp.com/3926363/buckets/27088350/todos/6423908592/)

[(Web) Add slide up animation to the modal on enter/exit](https://3.basecamp.com/3926363/buckets/27088350/todos/6423864906/)

## What was done:

- webflow cedar creek logo at `z-index 999`, so sent `z-index` for search to 1000
- restructured how collections were being rendered, switched `pages` and `content` positions
- added a sliding up and down animation to the modal

### Note: 
~~had to fiddle around to get Sliding down animation to work how I wanted it to, might be some issues relating to refreshes and url changes~~. 
Adding animations actually exposed these issues, rather than cause them.

**Relevant issue by adding animations tracked here:**

[(Web) View all showing both modal and web view](https://3.basecamp.com/3926363/buckets/27088350/todos/6438871997/)

[(Web) Two instances of modal/feed on refresh when searchParam is not null](https://3.basecamp.com/3926363/buckets/27088350/todos/6442722721/)

## How to test:

- open search, see that pages is above content
- Click around to see modal animations

<img width="1044" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/850af539-7ae7-497e-8327-a355fea85b96">

https://github.com/ApollosProject/apollos-embeds/assets/68402088/2530762a-e8e8-4324-ad30-6cb53c67ef35



