### PR TITLE
Support subtitles on all features

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/ActionListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ActionListFeature.js
@@ -21,7 +21,7 @@ function ActionListFeature(props = {}) {
   return (
     <Box>
       <Box padding="xs" fontWeight="600" color="base.gray" id="results">
-        {props.feature.title}
+        {props.feature.title || props.feature.subtitle}
       </Box>
       <Styled.List>
         {props.feature?.actions?.map((item, index) => {

--- a/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.js
@@ -15,7 +15,7 @@ function ChipListFeature(props = {}) {
   return (
     <Box>
       <Box padding="xs" fontWeight="600" color="base.gray" id="results">
-        {props.feature.title}
+        {props.feature.title || props.feature.subtitle}
       </Box>
       <Styled.List>
         {props.feature?.chips?.map(

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -92,7 +92,7 @@ function HorizontalCardListFeature(props = {}) {
     <Box pb="l" {...props}>
       <Box display="flex" alignItems="center" mb="xs">
         <H3 flex="1" mr="xs">
-          {props.feature.title}
+          {props.feature.title || props.feature.subtitle}
         </H3>
         {props?.feature?.cards?.length >= SHOW_VIEW_ALL_LIMIT &&
         props?.feature?.primaryAction ? (

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
@@ -91,7 +91,7 @@ function HorizontalMediaListFeature(props = {}) {
     <Box pb="xl" {...props}>
       <Box display="flex" alignItems="center" mb="xs">
         <H3 flex="1" mr="xs">
-          {props.feature.title}
+          {props.feature.title || props.feature.subtitle}
         </H3>
         {props?.feature?.items?.length >= SHOW_VIEW_ALL_LIMIT &&
         props?.feature?.primaryAction ? (

--- a/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
@@ -59,7 +59,7 @@ function VerticalCardListFeature(props = {}) {
     <Box pb="l" {...props}>
       <Box display="flex">
         <H3 flex="1" mb="xs">
-          {props.feature.title}
+          {props.feature.title || props.feature.subtitle}
         </H3>
         {props?.feature?.cards?.length >= 5 && props?.feature?.primaryAction ? (
           <Button

--- a/packages/web-shared/components/LivestreamSingle.js
+++ b/packages/web-shared/components/LivestreamSingle.js
@@ -178,7 +178,7 @@ function LivestreamSingle(props = {}) {
 
         {hasChildContent ? (
           <Box mb="l">
-            <H3 mb="xs">{props.feature.title}</H3>
+            <H3 mb="xs">{props.feature.title || props.feature.subtitle}</H3>
             <Box
               display="grid"
               gridTemplateColumns="repeat(3, 1fr)"

--- a/packages/web-shared/hooks/useFeatureFeed.js
+++ b/packages/web-shared/hooks/useFeatureFeed.js
@@ -52,6 +52,7 @@ export const FEED_FEATURES = gql`
 
           ... on HorizontalCardListFeature {
             title
+            subtitle
             cards {
               id
               title
@@ -96,6 +97,7 @@ export const FEED_FEATURES = gql`
           }
           ... on VerticalCardListFeature {
             title
+            subtitle
             cards {
               id
               title


### PR DESCRIPTION
Currently, in the Admin sometimes feature feeds get setup with subtitles and not titles. This PR defaults to the title and if one isn't present it will use the subtitle.
Basecamp: https://3.basecamp.com/3926363/buckets/27088350/todos/6419832929

Relevant links:
https://newspring.apollos.church/?root=FeatureFeed-567b0865-443f-4447-8fa4-ce5db221ecf1
http://newspring.localhost:3000/?root=FeatureFeed-567b0865-443f-4447-8fa4-ce5db221ecf1

Before
<img width="1178" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/1569c84e-b48e-48e1-814e-30eb2fb90352">
After
<img width="1221" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/944fb29b-b352-4cc0-8c9e-9e314c05170d">
