### PR TITLE
(Web) Buttons don't work in long form content items

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/ButtonFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ButtonFeature.js
@@ -8,21 +8,24 @@ import { Button, systemPropTypes } from '../../../ui-kit';
 
 function ButtonFeature(props = {}) {
   const navigate = useNavigate();
-
   // Event Handlers
   const handleActionPress = () => {
-    navigate({
-      pathname: '/',
-      search: `?id=${getURLFromType(props.relatedNode)}`,
-    });
+    if (props.feature?.action?.relatedNode?.url) {
+      window.open(props.feature?.action?.relatedNode?.url, '_blank');
+    } else {
+      navigate({
+        pathname: '/',
+        search: `?id=${getURLFromType(props.feature.action.relatedNode)}`,
+      });
+    }
   };
 
   return (
     <Button
       title={props.title || props.feature?.action?.title}
       icon={props.icon}
-      cursor={props.relatedNode ? 'pointer' : 'default'}
-      onClick={props.relatedNode && handleActionPress}
+      cursor={props.feature.action.relatedNode ? 'pointer' : 'default'}
+      onClick={props.feature.action.relatedNode && handleActionPress}
       width="100%"
     />
   );


### PR DESCRIPTION
## Basecamp Scope

[(Web) Buttons don't work in long form content items](https://3.basecamp.com/3926363/buckets/27088350/todos/6419852102/)

## What was done?

1. Edit the `ButtonFeature` component to correctly take in props

## How to test?

- Buttons in HTML content for Content single should have working buttons

https://github.com/ApollosProject/apollos-embeds/assets/68402088/5b4825f1-a808-43e4-9d3d-9935c94d293a


