### PR TITLE
(Web) Fix modal padding issues

### DIFF
--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -1,21 +1,21 @@
-import React, { useEffect, useState } from "react";
-import { systemPropTypes } from "../../ui-kit/_lib/system";
-import Styled from "./Modal.styles";
-import { Box } from "../../ui-kit";
-import { Searchbar } from "../../components";
-import Breadcrumbs from "../Breadcrumbs";
-import { useSearchParams } from "react-router-dom";
+import React, { useEffect, useState } from 'react';
+import { systemPropTypes } from '../../ui-kit/_lib/system';
+import Styled from './Modal.styles';
+import { Box } from '../../ui-kit';
+import { Searchbar } from '../../components';
+import Breadcrumbs from '../Breadcrumbs';
+import { useSearchParams } from 'react-router-dom';
 import {
   open as openModal,
   close as closeModal,
   set as setModal,
   useModal,
-} from "../../providers/ModalProvider";
+} from '../../providers/ModalProvider';
 import {
   reset as resetBreadcrumb,
   useBreadcrumbDispatch,
-} from "../../providers/BreadcrumbProvider";
-import { X } from "phosphor-react";
+} from '../../providers/BreadcrumbProvider';
+import { X } from 'phosphor-react';
 
 const Modal = (props = {}) => {
   const [state, dispatch] = useModal();
@@ -24,22 +24,20 @@ const Modal = (props = {}) => {
 
   useEffect(() => {
     // Watch for changes to the `id` search param
-    if (searchParams.get("id")) {
+    if (searchParams.get('id')) {
       dispatch(openModal());
-      dispatch(setModal(searchParams.get("id")));
+      dispatch(setModal(searchParams.get('id')));
     }
-    if (searchParams.get("id") === null) {
+    if (searchParams.get('id') === null) {
       dispatch(closeModal());
     }
   }, [dispatch, searchParams]);
 
   function handleCloseModal() {
     dispatch(closeModal());
-    setSearchParams("");
+    setSearchParams('');
     dispatchBreadcrumb(resetBreadcrumb());
   }
-
-  console.log(searchParams.get("id"));
 
   return (
     <Box>
@@ -53,14 +51,14 @@ const Modal = (props = {}) => {
                 mb="s"
                 alignItems="center"
                 justifyContent="space-between"
-                flexDirection={{ _: "column-reverse", sm: "row" }}
+                flexDirection={{ _: 'column-reverse', sm: 'row' }}
               >
-                <Box width={{ _: "0", sm: "10%" }}></Box>
+                <Box width={{ _: '0', sm: '10%' }}></Box>
                 <Box
                   width={{
-                    _: "100%",
-                    md: "700px",
-                    lg: "900px",
+                    _: '100%',
+                    md: '700px',
+                    lg: '900px',
                   }}
                   mx="auto"
                   justifyContent="center"
@@ -69,16 +67,16 @@ const Modal = (props = {}) => {
                   <Searchbar width="100%" />
                 </Box>
                 <Box
-                  width={{ _: "100%", sm: "10%" }}
-                  mb={{ _: "xs", sm: "0" }}
-                  ml={{ _: "0", sm: "xs" }}
+                  width={{ _: '100%', sm: '10%' }}
+                  mb={{ _: 'xs', sm: '0' }}
+                  ml={{ _: '0', sm: 'xs' }}
                   display="flex"
                   justifyContent="flex-end"
                   alignItems="center"
                 >
                   <Styled.Icon
                     onClick={handleCloseModal}
-                    ml={{ _: "auto", sm: "0" }}
+                    ml={{ _: 'auto', sm: '0' }}
                   >
                     <X size={16} weight="bold" />
                   </Styled.Icon>
@@ -87,9 +85,9 @@ const Modal = (props = {}) => {
               <Breadcrumbs />
               <Box
                 width={{
-                  _: "100%",
-                  md: "750px",
-                  lg: "1180px",
+                  _: '100%',
+                  md: '750px',
+                  lg: '1180px',
                 }}
               >
                 {state.content}

--- a/packages/web-shared/components/Modal/Modal.styles.js
+++ b/packages/web-shared/components/Modal/Modal.styles.js
@@ -49,6 +49,7 @@ const ModalContainer = withTheme(styled.div`
   background-color: #ffffff;
   overflow-y: scroll;
   padding: 40px;
+  box-sizing: border-box;
   @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
     padding: 16px;
   }

--- a/packages/web-shared/components/Modal/Modal.styles.js
+++ b/packages/web-shared/components/Modal/Modal.styles.js
@@ -63,6 +63,8 @@ const Icon = withTheme(styled.div`
   border-radius: 50%;
   display: flex;
   height: 32px;
+  min-height: 32px;
+  min-width: 32px;
   justify-content: center;
   line-height: 0;
   padding: 8px;

--- a/packages/web-shared/components/Profile/Profile.js
+++ b/packages/web-shared/components/Profile/Profile.js
@@ -70,8 +70,7 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
   return (
     <>
       <Styled.Profile>
-        <Card
-          p="xs"
+        <Styled.ProfileCard
           borderRadius={{
             _: '0%',
             sm: 'xxl',
@@ -81,8 +80,6 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
             sm: '350px',
             md: '520px',
           }}
-          height="100%"
-          border="1px solid rgba(0, 0, 0, 0.1)"
         >
           <Box display="flex" alignItems="center" justifyContent="end">
             <Styled.CloseIcon onClick={handleCloseProfile}>
@@ -264,7 +261,7 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
               </Styled.AppLinks>
             </>
           ) : null}
-        </Card>
+        </Styled.ProfileCard>
       </Styled.Profile>
       {showAuth && !state.token ? <AuthManager /> : null}
     </>

--- a/packages/web-shared/components/Profile/Profile.styles.js
+++ b/packages/web-shared/components/Profile/Profile.styles.js
@@ -1,7 +1,7 @@
 import { withTheme } from 'styled-components';
 import styled, { css } from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
-import { H4, utils } from '../../ui-kit';
+import { H4, Card, utils } from '../../ui-kit';
 import { system } from '../../ui-kit/_lib/system';
 import Color from 'color';
 
@@ -26,6 +26,14 @@ const Profile = withTheme(styled.div`
 const Title = withTheme(styled(H4)`
   color: ${themeGet('colors.text.secondary')};
   font-size: ${utils.rem('16px')};
+`);
+
+const ProfileCard = withTheme(styled(Card)`
+  height: 100%;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: ${themeGet('space.xs')};
+  box-sizing: border-box;
+  ${system};
 `);
 
 const CloseIcon = withTheme(styled.div`
@@ -83,6 +91,7 @@ const Styled = {
   CloseIcon,
   UploadIcon,
   AppLinks,
+  ProfileCard,
 };
 
 export default Styled;


### PR DESCRIPTION
## Basecamp Scope

[(Web) Fix modal padding issues](https://3.basecamp.com/3926363/buckets/27088350/todos/6438291134)

## What was done?

1. add `box-sizing: border-box;` to modal to fix padding issue
2. Fix "x" icon in modal being squished

## How to test?

- opening modal/auth profile should have padding all around
- when scrolling to the bottom of the page, padding from modal (hidden at the bottom of the page for animation) no longer should block content
- when resizing modal, the x button should remain circular

## Screenshots
1. This is how the padding should now look
<img width="500" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/f7bafeb8-3f02-4887-9b0c-a74f21d9b7d4">

##

2. This is the padding at the bottom of the page that should be gone now
<img width="500" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/c314911d-e740-492c-8df5-94753b93a982">

##

3. "X" icon after
<img width="500" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/4751ba97-f119-4aaf-81fd-3d647b9e5aba">

##

4.  "X" icon before
<img width="500" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/f7dd0503-2ffe-4bcb-a5dd-35171799e3d5">


