### PR TITLE
(Web Micro-Service) Fix search height when there is no Search Feed id

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -4,43 +4,43 @@ import React, {
   useMemo,
   createElement,
   Fragment,
-} from "react";
-import { useSearchParams } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   ClockCounterClockwise,
   MagnifyingGlass,
   CaretDown,
   CaretRight,
   X,
-} from "phosphor-react";
+} from 'phosphor-react';
 
-import algoliasearch from "algoliasearch/lite";
-import { createAutocomplete } from "@algolia/autocomplete-core";
+import algoliasearch from 'algoliasearch/lite';
+import { createAutocomplete } from '@algolia/autocomplete-core';
 import {
   getAlgoliaResults,
   parseAlgoliaHitHighlight,
-} from "@algolia/autocomplete-preset-algolia";
-import { createQuerySuggestionsPlugin } from "@algolia/autocomplete-plugin-query-suggestions";
-import { createLocalStorageRecentSearchesPlugin } from "@algolia/autocomplete-plugin-recent-searches";
-import "@algolia/autocomplete-theme-classic";
+} from '@algolia/autocomplete-preset-algolia';
+import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
+import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
+import '@algolia/autocomplete-theme-classic';
 
-import { FeatureFeedProvider } from "../../providers";
-import Feed from "../FeatureFeed";
-import { ResourceCard, Box } from "../../ui-kit";
+import { FeatureFeedProvider } from '../../providers';
+import Feed from '../FeatureFeed';
+import { ResourceCard, Box } from '../../ui-kit';
 
-import { useSearchState } from "../../providers/SearchProvider";
-import { getURLFromType } from "../../utils";
-import Styled from "./Search.styles";
+import { useSearchState } from '../../providers/SearchProvider';
+import { getURLFromType } from '../../utils';
+import Styled from './Search.styles';
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from "../../providers/BreadcrumbProvider";
+} from '../../providers/BreadcrumbProvider';
 import {
   open as openModal,
   set as setModal,
   useModal,
-} from "../../providers/ModalProvider";
+} from '../../providers/ModalProvider';
 
 const MOBILE_BREAKPOINT = 428;
 const appId = process.env.REACT_APP_ALGOLIA_APP_ID;
@@ -52,7 +52,7 @@ function Hit({ hit }) {
 }
 
 // Highlight text render
-function Highlight({ hit, attribute, tagName = "mark" }) {
+function Highlight({ hit, attribute, tagName = 'mark' }) {
   return createElement(
     Fragment,
     {},
@@ -70,7 +70,7 @@ function Highlight({ hit, attribute, tagName = "mark" }) {
 
 // Recent Searches Index Definition
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
-  key: "navbar",
+  key: 'navbar',
   transformSource({ source }) {
     return {
       ...source,
@@ -177,7 +177,7 @@ export default function Autocomplete({
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (searchParams.get("id") !== getURLFromType(item)) {
+    if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item)}`,
@@ -214,11 +214,11 @@ export default function Autocomplete({
       if (!hoverElement) {
         return;
       }
-      hoverElement.addEventListener("mouseover", function () {
+      hoverElement.addEventListener('mouseover', function () {
         parentElements.forEach(function (parentElement) {
           const children = parentElement.querySelectorAll(childClassName);
           for (let i = 0; i < children.length; i++) {
-            children[i].setAttribute("aria-selected", "false");
+            children[i].setAttribute('aria-selected', 'false');
           }
         });
       });
@@ -234,7 +234,7 @@ export default function Autocomplete({
         _highLightResult: { label: { value: value } },
       });
     }
-    autocomplete.setQuery("");
+    autocomplete.setQuery('');
     autocomplete.refresh();
   };
 
@@ -244,15 +244,15 @@ export default function Autocomplete({
     setAutocompleteState(updatedAutocompleteState);
 
     autocomplete.setIsOpen(!autocompleteState.isOpen);
-    inputRef.current?.[autocompleteState.isOpen ? "blur" : "focus"]();
+    inputRef.current?.[autocompleteState.isOpen ? 'blur' : 'focus']();
   };
 
   // (Desktop Specific Behavior): Hitting enter scrolls dropdown to results
   const scrollToResults = (event) => {
-    const resultsElement = document.getElementById("results");
+    const resultsElement = document.getElementById('results');
     event.preventDefault();
     if (resultsElement) {
-      resultsElement.scrollIntoView({ behavior: "smooth" });
+      resultsElement.scrollIntoView({ behavior: 'smooth' });
     }
   };
 
@@ -283,13 +283,13 @@ export default function Autocomplete({
         const panelElement =
           window.innerWidth < MOBILE_BREAKPOINT &&
           state.query !== props.prevState.query
-            ? document.getElementById("panel-top")
+            ? document.getElementById('panel-top')
             : null;
 
         if (panelElement) {
           panelElement.scrollIntoView({
-            behavior: "instant",
-            block: "start",
+            behavior: 'instant',
+            block: 'start',
           });
         }
         // (2) Synchronize the Autocomplete state with the React state.
@@ -299,7 +299,7 @@ export default function Autocomplete({
         return [
           // (3) Use an Algolia index source.
           {
-            sourceId: "pages",
+            sourceId: 'pages',
             getItemInputValue({ item }) {
               return item.query;
             },
@@ -326,7 +326,7 @@ export default function Autocomplete({
             },
           },
           {
-            sourceId: "content",
+            sourceId: 'content',
             getItemInputValue({ item }) {
               return item.query;
             },
@@ -356,8 +356,8 @@ export default function Autocomplete({
     });
   }, []);
 
-  const autoCompleteLabel = "autocomplete-1-label";
-  const autoCompleteId = "autocomplete-1-input";
+  const autoCompleteLabel = 'autocomplete-1-label';
+  const autoCompleteId = 'autocomplete-1-input';
 
   // Makes SSR consistent on aria aspects
   const containerProps = autocomplete.getRootProps({});
@@ -369,24 +369,24 @@ export default function Autocomplete({
 
   inputProps.id = autoCompleteId;
   formProps.onSubmit = scrollToResults;
-  containerProps["aria-labelledby"] = autoCompleteLabel;
-  inputProps["aria-labelledby"] = autoCompleteLabel;
-  panelProps["aria-labelledby"] = autoCompleteLabel;
+  containerProps['aria-labelledby'] = autoCompleteLabel;
+  inputProps['aria-labelledby'] = autoCompleteLabel;
+  panelProps['aria-labelledby'] = autoCompleteLabel;
 
   useEffect(() => {
     function handleClickOutside(event) {
-      if (autocompleteState.isOpen && !event.target.closest("#search")) {
+      if (autocompleteState.isOpen && !event.target.closest('#search')) {
         autocomplete.setIsOpen(false);
-        autocomplete.setQuery("");
+        autocomplete.setQuery('');
         setShowTextPrompt(true);
       }
     }
     function openDropdownMenu() {
-      document.body.style.overflow = "hidden";
+      document.body.style.overflow = 'hidden';
     }
 
     function closeDropdownMenu() {
-      document.body.style.overflow = "";
+      document.body.style.overflow = '';
     }
 
     if (autocompleteState.isOpen && window.innerWidth < MOBILE_BREAKPOINT) {
@@ -395,12 +395,12 @@ export default function Autocomplete({
       closeDropdownMenu();
     }
 
-    setAriaSelectedToFalseOnHover(".aa-List", ".aa-Item", ".empty-feed");
+    setAriaSelectedToFalseOnHover('.aa-List', '.aa-Item', '.empty-feed');
 
-    document.addEventListener("click", handleClickOutside);
+    document.addEventListener('click', handleClickOutside);
 
     return () => {
-      document.removeEventListener("click", handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     };
   }, [autocompleteState.isOpen, autocomplete, setShowTextPrompt]);
 
@@ -409,7 +409,7 @@ export default function Autocomplete({
     <div className="aa-Autocomplete" {...containerProps}>
       <form className="aa-Form" {...formProps}>
         <input ref={inputRef} className="aa-Input" {...inputProps} />
-        {inputProps.value !== "" ? (
+        {inputProps.value !== '' ? (
           <div className="aa-ClearButton" onClick={clearInput}>
             <Styled.IconWrapper>
               <X size={18} weight="fill" />
@@ -434,7 +434,7 @@ export default function Autocomplete({
             const { source, items } = collection;
             // Rendering of Query Suggestions
             if (
-              ["querySuggestionsPlugin", "recentSearchesPlugin"].includes(
+              ['querySuggestionsPlugin', 'recentSearchesPlugin'].includes(
                 collection.source.sourceId
               )
             ) {
@@ -453,7 +453,7 @@ export default function Autocomplete({
                         })}
                       >
                         {collection.source.sourceId ===
-                          "querySuggestionsPlugin" && (
+                          'querySuggestionsPlugin' && (
                           <QuerySuggestionItem
                             item={item}
                             autocomplete={autocomplete}
@@ -465,7 +465,7 @@ export default function Autocomplete({
                           />
                         )}
                         {collection.source.sourceId ===
-                          "recentSearchesPlugin" && (
+                          'recentSearchesPlugin' && (
                           <PastQueryItem
                             item={item}
                             autocomplete={autocomplete}
@@ -483,9 +483,9 @@ export default function Autocomplete({
             }
 
             // Rendering of regular items
-            return autocompleteState.query !== "" ? (
+            return autocompleteState.query !== '' ? (
               <div key={`source-${index}`} className="aa-Source">
-                {collection.source.sourceId === "content" && (
+                {collection.source.sourceId === 'content' && (
                   <Box
                     padding="xs"
                     fontWeight="600"
@@ -495,7 +495,7 @@ export default function Autocomplete({
                     Content
                   </Box>
                 )}
-                {collection.source.sourceId === "pages" && (
+                {collection.source.sourceId === 'pages' && (
                   <Box padding="xs" fontWeight="600" color="base.gray">
                     Pages
                   </Box>
@@ -518,7 +518,7 @@ export default function Autocomplete({
                           leadingAsset={item?.coverImage}
                           title={item?.title}
                           onClick={() => {
-                            if (collection.source.sourceId === "pages") {
+                            if (collection.source.sourceId === 'pages') {
                               return handleStaticActionPress(item);
                             }
                             return handleActionPress(item);
@@ -543,7 +543,7 @@ export default function Autocomplete({
             ) : null;
           })}
         {autocompleteState.isOpen &&
-        autocompleteState.query === "" &&
+        autocompleteState.query === '' &&
         searchState.searchFeed ? (
           <Box className="empty-feed">
             <FeatureFeedProvider

--- a/packages/web-shared/components/Searchbar/Search.styles.js
+++ b/packages/web-shared/components/Searchbar/Search.styles.js
@@ -1,16 +1,16 @@
-import { withTheme } from "styled-components";
-import styled, { css } from "styled-components";
-import { themeGet } from "@styled-system/theme-get";
+import { withTheme } from 'styled-components';
+import styled, { css } from 'styled-components';
+import { themeGet } from '@styled-system/theme-get';
 
-import { H4, TypeStyles } from "../../ui-kit/Typography";
-import { utils } from "../../ui-kit";
-import { system } from "../../ui-kit/_lib/system";
+import { H4, TypeStyles } from '../../ui-kit/Typography';
+import { utils } from '../../ui-kit';
+import { system } from '../../ui-kit/_lib/system';
 
 const showDropdown = ({ dropdown }) => {
   if (dropdown) {
     return css`
-      border-radius: ${themeGet("radii.xxl")} ${themeGet("radii.xxl")} 0px 0px;
-      @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
+      border-radius: ${themeGet('radii.xxl')} ${themeGet('radii.xxl')} 0px 0px;
+      @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
         border-radius: 0px;
         position: fixed;
         bottom: 0;
@@ -22,7 +22,7 @@ const showDropdown = ({ dropdown }) => {
     `;
   } else {
     return css`
-      border-radius: ${themeGet("radii.xxl")};
+      border-radius: ${themeGet('radii.xxl')};
     `;
   }
 };
@@ -30,12 +30,14 @@ const showDropdown = ({ dropdown }) => {
 const showPanel = ({ dropdown }) => {
   if (dropdown) {
     return css`
-      @media screen and (min-width: ${themeGet("breakpoints.sm")}) {
-        height: 600px;
+      @media screen and (min-width: ${themeGet('breakpoints.sm')}) {
+        max-height: 600px;
+        padding-bottom: 15px;
       }
-      @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
+      @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
         height: 100vh;
         z-index: 1000;
+        padding-bottom: 15px;
       }
     `;
   } else {
@@ -47,8 +49,8 @@ const showPanel = ({ dropdown }) => {
 
 const Wrapper = withTheme(styled.div`
   align-items: center;
-  background: ${themeGet("colors.base.white")};
-  box-shadow: ${themeGet("shadows.medium")};
+  background: ${themeGet('colors.base.white')};
+  box-shadow: ${themeGet('shadows.medium')};
   display: flex;
   height: 60px;
   justify-content: space-between;
@@ -63,8 +65,8 @@ const Wrapper = withTheme(styled.div`
   .aa-Panel {
     width: 100%;
     left: 0;
-    background: ${themeGet("colors.base.white")};
-    box-shadow: ${themeGet("shadows.mediumBottom")};
+    background: ${themeGet('colors.base.white')};
+    box-shadow: ${themeGet('shadows.mediumBottom')};
     transition: 0s;
     overflow-y: scroll;
     overflow-x: hidden;
@@ -96,11 +98,11 @@ const TextPrompt = withTheme(styled.div`
   white-space: nowrap;
   width: 100%;
 
-  @media screen and (max-width: ${themeGet("breakpoints.md")}) {
+  @media screen and (max-width: ${themeGet('breakpoints.md')}) {
     max-width: 50%;
   }
 
-  @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
+  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
     max-width: 47%;
   }
 
@@ -153,22 +155,22 @@ const Input = withTheme(styled.input`
 const X = withTheme(styled.div`
   color: #27272e54;
   &:hover {
-    color: ${themeGet("colors.base.secondary")};
+    color: ${themeGet('colors.base.secondary')};
     cursor: pointer;
   }
   ${system}
 `);
 
 const Title = withTheme(styled(H4)`
-  font-size: ${utils.rem("16px")};
-  color: ${themeGet("colors.text.secondary")};
+  font-size: ${utils.rem('16px')};
+  color: ${themeGet('colors.text.secondary')};
 `);
 
 const IconWrapper = withTheme(styled.div`
   color: #27272e54;
   transition: 0.2s;
   &:hover {
-    color: ${themeGet("colors.base.secondary")};
+    color: ${themeGet('colors.base.secondary')};
     cursor: pointer;
   }
   ${system}


### PR DESCRIPTION
## Basecamp Scope

[(Web Micro-Service) Fix search height when there is no Search Feed id](https://3.basecamp.com/3926363/buckets/27088350/todos/6419894036)

## What was done?

1. added `max-height` to modal instead of set height
2. add padding to bottom of panel just to give some space for the last item 

## How to test?

- open search
- the panel should no longer be a set height, so if there is no feature feed, there should be no whitespace

<img width="1219" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/65ac07b2-b88c-4511-83c9-e183d82a1f4d">
