### PR TITLE
Remove authEnabled, auth is always needed now for some features

### DIFF
--- a/packages/web-shared/hooks/useInteractWithNode.js
+++ b/packages/web-shared/hooks/useInteractWithNode.js
@@ -47,7 +47,7 @@ function transformVariables(variables) {
 }
 
 function useInteractWithNode(options = {}) {
-  const { authEnabled, authenticated } = useAuthState();
+  const { authenticated } = useAuthState();
   const [_mutation, result] = useMutation(INTERACT_WITH_NODE, options);
 
   /*
@@ -58,7 +58,7 @@ function useInteractWithNode(options = {}) {
   */
   const mutation = useCallback(
     (mutOpts = { variables: {} }) => {
-      if (authEnabled && authenticated) {
+      if (authenticated) {
         return _mutation({
           ...mutOpts,
           variables: transformVariables(mutOpts.variables),
@@ -67,7 +67,7 @@ function useInteractWithNode(options = {}) {
 
       return Promise.resolve();
     },
-    [_mutation, authEnabled, authenticated]
+    [_mutation, authenticated]
   );
 
   return [mutation, result];

--- a/packages/web-shared/providers/AuthProvider.js
+++ b/packages/web-shared/providers/AuthProvider.js
@@ -14,11 +14,6 @@ const AuthStateContext = createContext();
 const AuthDispatchContext = createContext();
 
 const initialState = {
-  // This is stored as state, but it should *not* be mutated.
-  // Storing on state simplifies/centralizes views that need
-  // to know if Auth is enabled or not.
-  authEnabled: process.env.REACT_APP_ENABLE_AUTH === 'true',
-
   initialized: false,
   authenticated: false,
   identity: null,
@@ -78,14 +73,8 @@ function reducer(state, action) {
 
 function AuthProvider(props = {}) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const {
-    authEnabled,
-    initialized,
-    authenticated,
-    token,
-    refreshToken,
-    anonymousId,
-  } = state;
+  const { initialized, authenticated, token, refreshToken, anonymousId } =
+    state;
 
   // Initialize auth state
   useEffect(() => {
@@ -96,7 +85,7 @@ function AuthProvider(props = {}) {
       );
       const storedAnonymousId = window.localStorage.getItem(ANONYMOUS_ID);
 
-      if (authEnabled && storedToken) {
+      if (storedToken) {
         dispatch(
           update({
             initialized: true,
@@ -114,7 +103,7 @@ function AuthProvider(props = {}) {
     if (!initialized) {
       restoreAuthentication();
     }
-  }, [authEnabled, initialized]);
+  }, [initialized]);
 
   // Respond to changes in auth state (login/logout)
   useEffect(() => {


### PR DESCRIPTION
This fixes an issue when a user refreshes or changes the route of the website state is wiped out so we lost the reference to the auth token. We no longer need this check since auth is a core needed element for some features to work correctly.

Note: This also could have been fixed by adding a environment variable to the webflow app, but I don't think we should do that since it would just complicate the setup of web-embeds for customers 

https://github.com/ApollosProject/apollos-embeds/assets/2528817/aad3b9d4-05c3-4d6d-a3e0-19cfc39efcc9

