### PR TITLE
(Web) Modal animation flashes on page load

### DIFF
--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -42,9 +42,9 @@ const Modal = (props = {}) => {
   return (
     <Box>
       <Styled.Modal show={state.isOpen}>
-        <Styled.ModalContainer>
-          {state.content ? (
-            <>
+        {state.content ? (
+          <>
+            <Styled.ModalContainer>
               <Box
                 width="100%"
                 display="flex"
@@ -92,9 +92,9 @@ const Modal = (props = {}) => {
               >
                 {state.content}
               </Box>
-            </>
-          ) : null}
-        </Styled.ModalContainer>
+            </Styled.ModalContainer>
+          </>
+        ) : null}
       </Styled.Modal>
     </Box>
   );


### PR DESCRIPTION
## Basecamp Scope

[(Web) Modal animation flashes on page load](https://3.basecamp.com/3926363/buckets/27088350/todos/6464477825/edit?replace=true)

## What was done?

1. Have the `ModalContainer`, which has a pure white background, not be rendered unless there is content.
2. This should make it so that the animation does not appear visually.

## How to test?

1. refresh page, there should be no animation flash

## Before (with black background for visual)
https://github.com/ApollosProject/apollos-embeds/assets/68402088/3a7db7fe-5481-42ba-9ff8-b9b7c3a8f5a6


## After (with black background for visual)
https://github.com/ApollosProject/apollos-embeds/assets/68402088/ba27b05e-2a14-4adf-8e5b-188c931836e0



