### PR TITLE
(Web) Profile Details Resource item styles broken

### DIFF
--- a/packages/web-shared/ui-kit/ListItem/ListItem.styles.js
+++ b/packages/web-shared/ui-kit/ListItem/ListItem.styles.js
@@ -13,6 +13,7 @@ const ListItem = withTheme(styled.div`
   width: 100%;
   height: 62px;
   gap: ${themeGet('space.xs')};
+  box-sizing: border-box;
   ${system};
 `);
 


### PR DESCRIPTION
## Basecamp Scope

[(Web) Profile Details Resource item styles broken](https://3.basecamp.com/3926363/buckets/27088350/todos/6455332436)
## What was done?

1. Add `border-box` to `ListItem` in Profile so that they stay within the Box that has been defined for it

## How to test?

### (Header for what is being tested)

1. Go to profile
2. Buttons should look normal now

<img width="500" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/2a9599cd-c267-4237-980a-3504ad857caf">

<img width="500" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/50c826e5-f6a0-4c0f-ae8b-82f45dd2c579">

