### PR TITLE
(Web) Avatar Placeholder and adding a image icon doesn't overlap correctly

### DIFF
--- a/packages/web-shared/components/Profile/Profile.js
+++ b/packages/web-shared/components/Profile/Profile.js
@@ -111,9 +111,13 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
                       width="72px"
                     />
                   ) : (
-                    <Box color="base.primary">
+                    <Box
+                      color="base.primary"
+                      position="relative"
+                      margin="-10px"
+                    >
                       <UserCirclePlus
-                        size={84}
+                        size={90}
                         weight="fill"
                         color={themeGet('colors.base.primary')({ theme })}
                       />


### PR DESCRIPTION
## Basecamp Scope

[(Web) Avatar Placeholder and adding a image icon doesn't overlap correctly](https://3.basecamp.com/3926363/buckets/27088350/todos/6455343544)

## What was done?

1. Make Avatar Placeholder image bigger and give it negative margins
2. Negative margins since svg has padding, so increasing size alone makes the gap larger

## How to test?

### (Header for what is being tested)

1. Go to profile and see that camera icon is overlapping avatar placeholder

Before:
<img width="150" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/2aee9dfe-9a8f-4b9b-87c5-f8ff2219c69c">

After:
<img width="150" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/dff9a947-d973-4689-bf11-06d28ea815cf">

Comparison to with image:
<img width="150" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/4268dd86-1fb8-45de-9cc5-ee6b16ab0884">


