### PR TITLE
(Web) Reduce the display size of images on the Content Single

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -1,17 +1,17 @@
-import React, { useEffect } from "react";
-import PropTypes from "prop-types";
-import format from "date-fns/format";
-import addMinutes from "date-fns/addMinutes";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import format from 'date-fns/format';
+import addMinutes from 'date-fns/addMinutes';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { getURLFromType, parseDescriptionLinks } from "../utils";
-import FeatureFeed from "./FeatureFeed";
-import FeatureFeedComponentMap from "./FeatureFeed/FeatureFeedComponentMap";
+import { getURLFromType, parseDescriptionLinks } from '../utils';
+import FeatureFeed from './FeatureFeed';
+import FeatureFeedComponentMap from './FeatureFeed/FeatureFeedComponentMap';
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from "../providers/BreadcrumbProvider";
-import { set as setModal, useModal } from "../providers/ModalProvider";
+} from '../providers/BreadcrumbProvider';
+import { set as setModal, useModal } from '../providers/ModalProvider';
 
 import {
   Box,
@@ -24,10 +24,10 @@ import {
   MediaItem,
   BodyText,
   ShareButton,
-} from "../ui-kit";
-import { useVideoMediaProgress } from "../hooks";
-import VideoPlayer from "./VideoPlayer";
-import InteractWhenLoaded from "./InteractWhenLoaded";
+} from '../ui-kit';
+import { useVideoMediaProgress } from '../hooks';
+import VideoPlayer from './VideoPlayer';
+import InteractWhenLoaded from './InteractWhenLoaded';
 
 function ContentSingle(props = {}) {
   const navigate = useNavigate();
@@ -50,7 +50,7 @@ function ContentSingle(props = {}) {
   useEffect(() => {
     if (!state.modal && invalidPage) {
       navigate({
-        pathname: "/",
+        pathname: '/',
       });
     }
   }, [invalidPage, navigate]);
@@ -92,7 +92,7 @@ function ContentSingle(props = {}) {
   const formattedPublishDate = props?.data?.publishDate
     ? format(
         addMinutes(publishDate, publishDate.getTimezoneOffset()),
-        "MMMM do, yyyy"
+        'MMMM do, yyyy'
       )
     : null;
 
@@ -104,7 +104,7 @@ function ContentSingle(props = {}) {
   );
 
   const handleActionPress = (item) => {
-    if (searchParams.get("id") !== getURLFromType(item)) {
+    if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item)}`,
@@ -125,9 +125,15 @@ function ContentSingle(props = {}) {
         <InteractWhenLoaded
           loading={props.loading}
           nodeId={props.data.id}
-          action={"VIEW"}
+          action={'VIEW'}
         />
-        <Box mb="base" borderRadius="xl" overflow="hidden">
+        <Box
+          mb="base"
+          borderRadius="xl"
+          overflow="hidden"
+          width={{ _: '100%', lg: '85%' }}
+          margin="0 auto"
+        >
           {props.data?.videos[0] ? (
             <VideoPlayer
               userProgress={userProgress}
@@ -135,12 +141,17 @@ function ContentSingle(props = {}) {
               coverImage={coverImage?.sources[0]?.uri}
             />
           ) : (
-            <Box
-              backgroundSize="cover"
-              paddingBottom="56.25%"
-              backgroundPosition="center"
-              backgroundImage={`url(${coverImage?.sources[0]?.uri})`}
-            />
+            <Box backgroundColor="neutral.gray5" borderRadius="xl">
+              <Box
+                backgroundSize="cover"
+                paddingBottom="56.25%"
+                backgroundPosition="center"
+                backgroundImage={`url(${coverImage?.sources[0]?.uri})`}
+                backgroundRepeat="no-repeat"
+                maxWidth="750px"
+                margin="0 auto"
+              />
+            </Box>
           )}
         </Box>
 
@@ -148,13 +159,13 @@ function ContentSingle(props = {}) {
           <Box
             display="flex"
             flexDirection={{
-              _: "column",
-              md: "row",
+              _: 'column',
+              md: 'row',
             }}
             justifyContent="space-between"
             alignItems={{
-              _: "start",
-              md: "center",
+              _: 'start',
+              md: 'center',
             }}
             mb="s"
           >
@@ -166,7 +177,7 @@ function ContentSingle(props = {}) {
                 {parentChannel.name ? (
                   <BodyText
                     color="text.secondary"
-                    mb={title && !hasChildContent ? "xxs" : ""}
+                    mb={title && !hasChildContent ? 'xxs' : ''}
                   >
                     {parentChannel.name}
                   </BodyText>
@@ -183,8 +194,8 @@ function ContentSingle(props = {}) {
             </Box>
             <Box
               mt={{
-                _: "xs",
-                md: "0",
+                _: 'xs',
+                md: '0',
               }}
             >
               <ShareButton contentTitle={title} />
@@ -194,8 +205,8 @@ function ContentSingle(props = {}) {
           {/* Children Count */}
           {showEpisodeCount ? (
             <H4 color="text.secondary" mr="l">
-              {childContentItems.length}{" "}
-              {`Episode${childContentItems.length === 1 ? "" : "s"}`}
+              {childContentItems.length}{' '}
+              {`Episode${childContentItems.length === 1 ? '' : 's'}`}
             </H4>
           ) : null}
           {htmlContent ? (
@@ -217,13 +228,13 @@ function ContentSingle(props = {}) {
               display="grid"
               gridGap="30px"
               gridTemplateColumns={{
-                _: "repeat(1, minmax(0, 1fr));",
-                md: "repeat(2, minmax(0, 1fr));",
-                lg: "repeat(3, minmax(0, 1fr));",
+                _: 'repeat(1, minmax(0, 1fr));',
+                md: 'repeat(2, minmax(0, 1fr));',
+                lg: 'repeat(3, minmax(0, 1fr));',
               }}
               padding={{
-                _: "30px",
-                md: "0",
+                _: '30px',
+                md: '0',
               }}
             >
               {childContentItems?.map((item, index) => (
@@ -247,13 +258,13 @@ function ContentSingle(props = {}) {
               display="grid"
               gridGap="30px"
               gridTemplateColumns={{
-                _: "repeat(1, minmax(0, 1fr));",
-                md: "repeat(2, minmax(0, 1fr));",
-                lg: "repeat(3, minmax(0, 1fr));",
+                _: 'repeat(1, minmax(0, 1fr));',
+                md: 'repeat(2, minmax(0, 1fr));',
+                lg: 'repeat(3, minmax(0, 1fr));',
               }}
               padding={{
-                _: "30px",
-                md: "0",
+                _: '30px',
+                md: '0',
               }}
             >
               {siblingContentItems?.map((item, index) => (

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -121,19 +121,14 @@ function ContentSingle(props = {}) {
 
   return (
     <>
-      <Box margin="0 auto">
+      {/* TODO: Max width set to 750px due to low resolution pictures. Can be increased as higher quality images are used */}
+      <Box margin="0 auto" maxWidth="750px">
         <InteractWhenLoaded
           loading={props.loading}
           nodeId={props.data.id}
           action={'VIEW'}
         />
-        <Box
-          mb="base"
-          borderRadius="xl"
-          overflow="hidden"
-          width={{ _: '100%', lg: '750px' }}
-          margin="0 auto"
-        >
+        <Box mb="base" borderRadius="xl" overflow="hidden" width="100%">
           {props.data?.videos[0] ? (
             <VideoPlayer
               userProgress={userProgress}
@@ -147,8 +142,6 @@ function ContentSingle(props = {}) {
               backgroundPosition="center"
               backgroundImage={`url(${coverImage?.sources[0]?.uri})`}
               backgroundRepeat="no-repeat"
-              maxWidth="750px"
-              margin="0 auto"
             />
           )}
         </Box>

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -131,7 +131,7 @@ function ContentSingle(props = {}) {
           mb="base"
           borderRadius="xl"
           overflow="hidden"
-          width={{ _: '100%', lg: '85%' }}
+          width={{ _: '100%', lg: '750px' }}
           margin="0 auto"
         >
           {props.data?.videos[0] ? (
@@ -141,17 +141,15 @@ function ContentSingle(props = {}) {
               coverImage={coverImage?.sources[0]?.uri}
             />
           ) : (
-            <Box backgroundColor="neutral.gray5" borderRadius="xl">
-              <Box
-                backgroundSize="cover"
-                paddingBottom="56.25%"
-                backgroundPosition="center"
-                backgroundImage={`url(${coverImage?.sources[0]?.uri})`}
-                backgroundRepeat="no-repeat"
-                maxWidth="750px"
-                margin="0 auto"
-              />
-            </Box>
+            <Box
+              backgroundSize="cover"
+              paddingBottom="56.25%"
+              backgroundPosition="center"
+              backgroundImage={`url(${coverImage?.sources[0]?.uri})`}
+              backgroundRepeat="no-repeat"
+              maxWidth="750px"
+              margin="0 auto"
+            />
           )}
         </Box>
 


### PR DESCRIPTION
## Basecamp Scope

[(Web) Reduce the display size of images on the Content Single](https://3.basecamp.com/3926363/buckets/27088350/todos/6459537200)

## What was done?

1. reduce image width on larger screens + added background color to (according to chatGPT): "mitigate the visual impact of stretching the image while maintaining a cohesive design"
2. Added max width of 750px to images (might not be necessary when higher res pictures are uploaded)

_Note: This probably can be run by a designer as well_

## How to test?

1. Go to any content with image, should have responsiveness as shown below

https://github.com/ApollosProject/apollos-embeds/assets/68402088/0e249309-84c7-4510-bd5b-65d51ed9874c


Before (takes up entire width):
<img width="1446" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/96806a72-1121-4c37-8f7d-7e457025174a">

