### PR TITLE
(Web) View all showing both modal and web view

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -1,8 +1,8 @@
-import React from "react";
-import get from "lodash/get";
-import { useSearchParams } from "react-router-dom";
+import React from 'react';
+import get from 'lodash/get';
+import { useSearchParams } from 'react-router-dom';
 
-import { getURLFromType } from "../../../utils";
+import { getURLFromType } from '../../../utils';
 import {
   ContentCard,
   Box,
@@ -10,19 +10,19 @@ import {
   systemPropTypes,
   Button,
   ButtonGroup,
-} from "../../../ui-kit";
+} from '../../../ui-kit';
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from "../../../providers/BreadcrumbProvider";
+} from '../../../providers/BreadcrumbProvider';
 import {
   open as openModal,
   set as setModal,
   useModal,
-} from "../../../providers/ModalProvider";
-import { CaretRight } from "phosphor-react";
+} from '../../../providers/ModalProvider';
+import { CaretRight } from 'phosphor-react';
 
-import Carousel from "react-multi-carousel";
+import Carousel from 'react-multi-carousel';
 
 const SHOW_VIEW_ALL_LIMIT = 5;
 
@@ -50,7 +50,7 @@ function HorizontalCardListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (searchParams.get("id") !== getURLFromType(item.relatedNode)) {
+    if (searchParams.get('id') !== getURLFromType(item.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item.relatedNode)}`,
@@ -68,7 +68,7 @@ function HorizontalCardListFeature(props = {}) {
 
   const handlePrimaryActionPress = () => {
     if (
-      searchParams.get("id") !==
+      searchParams.get('id') !==
       getURLFromType(props?.feature?.primaryAction.relatedNode)
     ) {
       dispatchBreadcrumb(
@@ -80,11 +80,13 @@ function HorizontalCardListFeature(props = {}) {
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      setSearchParams({ id, action: "viewall" });
+      state.modal
+        ? setSearchParams({ id })
+        : setSearchParams({ id, action: 'viewall' });
     }
-    if (state.modal) {
-      dispatch(openModal());
-    }
+    // if (state.modal) {
+    //   dispatch(openModal());
+    // }
   };
 
   if (props?.feature?.cards?.length === 0 || !props?.feature?.cards) {
@@ -126,7 +128,7 @@ function HorizontalCardListFeature(props = {}) {
               title={item.title}
               summary={item.summary}
               onClick={() => handleActionPress(item)}
-              videoMedia={get(item, "relatedNode?.videos[0]", null)}
+              videoMedia={get(item, 'relatedNode?.videos[0]', null)}
             />
           ))}
         </Carousel>
@@ -139,7 +141,7 @@ function HorizontalCardListFeature(props = {}) {
           px="l"
           textAlign="center"
         >
-          {props.feature.title === "Continue Watching" ? (
+          {props.feature.title === 'Continue Watching' ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!
             </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -84,9 +84,6 @@ function HorizontalCardListFeature(props = {}) {
         ? setSearchParams({ id })
         : setSearchParams({ id, action: 'viewall' });
     }
-    // if (state.modal) {
-    //   dispatch(openModal());
-    // }
   };
 
   if (props?.feature?.cards?.length === 0 || !props?.feature?.cards) {

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
@@ -1,8 +1,8 @@
-import React from "react";
-import get from "lodash/get";
-import { useSearchParams } from "react-router-dom";
+import React from 'react';
+import get from 'lodash/get';
+import { useSearchParams } from 'react-router-dom';
 
-import { getURLFromType } from "../../../utils";
+import { getURLFromType } from '../../../utils';
 import {
   Box,
   H3,
@@ -10,19 +10,19 @@ import {
   Button,
   MediaItem,
   ButtonGroup,
-} from "../../../ui-kit";
+} from '../../../ui-kit';
 import {
   add as addBreadcrumb,
   useBreadcrumbDispatch,
-} from "../../../providers/BreadcrumbProvider";
+} from '../../../providers/BreadcrumbProvider';
 import {
   open as openModal,
   set as setModal,
   useModal,
-} from "../../../providers/ModalProvider";
+} from '../../../providers/ModalProvider';
 
-import Carousel from "react-multi-carousel";
-import { CaretRight } from "phosphor-react";
+import Carousel from 'react-multi-carousel';
+import { CaretRight } from 'phosphor-react';
 const SHOW_VIEW_ALL_LIMIT = 5;
 
 const responsive = {
@@ -49,7 +49,7 @@ function HorizontalMediaListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (searchParams.get("id") !== getURLFromType(item.relatedNode)) {
+    if (searchParams.get('id') !== getURLFromType(item.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item.relatedNode)}`,
@@ -67,7 +67,7 @@ function HorizontalMediaListFeature(props = {}) {
 
   const handlePrimaryActionPress = () => {
     if (
-      searchParams.get("id") !==
+      searchParams.get('id') !==
       getURLFromType(props?.feature?.primaryAction.relatedNode)
     ) {
       dispatchBreadcrumb(
@@ -79,11 +79,13 @@ function HorizontalMediaListFeature(props = {}) {
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      setSearchParams({ id, action: "viewall" });
+      state.modal
+        ? setSearchParams({ id })
+        : setSearchParams({ id, action: 'viewall' });
     }
-    if (state.modal) {
-      dispatch(openModal());
-    }
+    // if (state.modal) {
+    //   dispatch(openModal());
+    // }
   };
 
   if (props?.feature?.items?.length === 0 || !props?.feature?.items) {
@@ -127,7 +129,7 @@ function HorizontalMediaListFeature(props = {}) {
                 title={item.title}
                 summary={item.summary}
                 onClick={() => handleActionPress(item)}
-                videoMedia={get(item, "relatedNode?.videos[0]", null)}
+                videoMedia={get(item, 'relatedNode?.videos[0]', null)}
               />
             );
           })}
@@ -141,7 +143,7 @@ function HorizontalMediaListFeature(props = {}) {
           px="l"
           textAlign="center"
         >
-          {props.feature.title === "Continue Watching" ? (
+          {props.feature.title === 'Continue Watching' ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!
             </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
@@ -83,9 +83,6 @@ function HorizontalMediaListFeature(props = {}) {
         ? setSearchParams({ id })
         : setSearchParams({ id, action: 'viewall' });
     }
-    // if (state.modal) {
-    //   dispatch(openModal());
-    // }
   };
 
   if (props?.feature?.items?.length === 0 || !props?.feature?.items) {

--- a/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
@@ -51,9 +51,12 @@ function VerticalCardListFeature(props = {}) {
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      setSearchParams({ id, action: 'viewall' });
+      state.modal
+        ? setSearchParams({ id })
+        : setSearchParams({ id, action: 'viewall' });
     }
   };
+
   const cards = props.feature?.cards;
   return (
     <Box pb="l" {...props}>


### PR DESCRIPTION
## Basecamp Scope

[(Web) View all showing both modal and web view](https://3.basecamp.com/3926363/buckets/27088350/todos/6438871997)

## What was done?

1. Update `handlePrimaryActionPress` in `HorizontalCardListFeature` and `HorizontalMediaListFeature` to add viewall action to url depending on if `state.modal` is true or false

## How to test?

1. Go to any Horizontal List Feature that has a viewall button
2. When modal="true", the modal should show the modal with the FeatureFeedGridList, and you shouldn't see it render in the background
3. When modal="false", it should have the same function as before

Before (can see FeatureFeed change to grid in the background as the modal slides up):

https://github.com/ApollosProject/apollos-embeds/assets/68402088/859904a3-100a-4164-b96d-b9e1449229cd


After:

https://github.com/ApollosProject/apollos-embeds/assets/68402088/7ac876d6-adbc-4689-a306-686a2959561e


