### PR TITLE
Support HorizontalMediaListFeature and live items

### DIFF
--- a/packages/web-shared/hooks/useFeatureFeed.js
+++ b/packages/web-shared/hooks/useFeatureFeed.js
@@ -49,7 +49,38 @@ export const FEED_FEATURES = gql`
               }
             }
           }
-
+          ... on HorizontalMediaListFeature {
+            id
+            title
+            items {
+              id
+              __typename
+              title
+              coverImage {
+                sources {
+                  uri
+                }
+              }
+              relatedNode {
+                id
+                ... on Livestream {
+                  __typename
+                  title
+                  start
+                  durationInSeconds
+                  stream {
+                    id
+                    originId
+                    originType
+                    duration
+                    sources {
+                      uri
+                    }
+                  }
+                }
+              }
+            }
+          }
           ... on HorizontalCardListFeature {
             title
             subtitle


### PR DESCRIPTION
Adds HorizontalMediaListFeature to the feature feed hook so we support media items and live items.

<img width="1172" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/9a0f69db-ea4d-46ca-be8c-534ea1d39dde">
