### PR TITLE
(Web) HeroListFeature not rendering correctly

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -115,7 +115,7 @@ function HeroListFeature(props = {}) {
               title="Watch now"
               onClick={handleWatchNowPress}
             />
-props?.feature?.primaryAction?.relatedNode !== null ? (
+            {props?.feature?.primaryAction?.relatedNode !== null ? (
               <Button
                 title={props.feature.primaryAction.title}
                 onClick={handlePrimaryActionClick}


### PR DESCRIPTION
## Basecamp Scope

[(Web) HeroListFeature not rendering correctly](https://3.basecamp.com/3926363/buckets/27088350/todos/6499872460)

## What was done?

1. Fix Typo in code

## How to test?

1. Open feed with HeroListFeature, should no longer show the code

<img width="680" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/340808cc-4525-4863-a067-9f9d24aac991">

<img width="934" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/a948ca25-0952-4a27-8c42-44e4cc8ef536">

