### PR TITLE
(Web) Search placeholder text is getting cut off

### DIFF
--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -40,16 +40,20 @@ const Searchbar = (props = {}) => {
     <Styled.TextPrompt>
       {!isMobile ? textWelcome : null}
 
-      <span
+      <Box
+        as="span"
         style={{
           overflow: 'hidden',
           whiteSpace: 'nowrap',
           textOverflow: 'ellipsis',
-          width: '150px',
+        }}
+        width={{
+          _: '125px',
+          sm: '400px',
         }}
       >
         What can we help you find?
-      </span>
+      </Box>
     </Styled.TextPrompt>
   );
 


### PR DESCRIPTION
## Basecamp Scope

[(Web) Search placeholder text is getting cut off](https://3.basecamp.com/3926363/buckets/27088350/todos/6496610157)

## What was done?

1. Have width cutoff for ellipses be shorter only for mobile resolution, and larger for desktop sizes to prevent early cutoffs

## How to test?

1. Resize window screen. The cutoff for the search placeholder text should make more sense

https://github.com/ApollosProject/apollos-embeds/assets/68402088/bb78ba7d-6b47-400d-8fec-5f852bdbf5b6



