### PR TITLE
(Web) Hero List Feature erroring out from null values

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -56,6 +56,7 @@ function HeroListFeature(props = {}) {
     );
   };
 
+  console.log(props?.feature?.primaryAction?.relatedNode);
   return (
     <Box mb="base" minWidth="180px" {...props}>
       {/* Content */}
@@ -115,9 +116,9 @@ function HeroListFeature(props = {}) {
               title="Watch now"
               onClick={handleWatchNowPress}
             />
-            {props?.feature?.primaryAction?.relatedNode !== null ? (
+            {props?.feature?.primaryAction?.relatedNode ? (
               <Button
-                title={props.feature.primaryAction.title}
+                title={props?.feature?.primaryAction?.title}
                 onClick={handlePrimaryActionClick}
                 variant="secondary"
               />

--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -56,7 +56,6 @@ function HeroListFeature(props = {}) {
     );
   };
 
-  console.log(props?.feature?.primaryAction?.relatedNode);
   return (
     <Box mb="base" minWidth="180px" {...props}>
       {/* Content */}


### PR DESCRIPTION
## Basecamp Scope
[(Web) Hero List Feature erroring out from null values](https://3.basecamp.com/3926363/buckets/27088350/todos/6509857115)

## What was done?

1. Have `props?.feature?.primaryAction?.relatedNode` be checked for if it is a falsy value rather than just null, as it will try and render a button when `undefined` is returned
2. Add optional chaining to title to avoid erroring out

## How to test?

1. Used this feature feed to check:
```
 <div
      data-type="FeatureFeed"
      data-church="apollos_demo"
      data-feature-feed="FeatureFeed:3040b753-9462-4705-ba5e-4a4aad93325b"
      data-modal="true"
      class="apollos-widget"
    ></div>
```

<img width="531" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/6e852311-f4cc-4121-b765-6f72a21aeea8">
