### PR TITLE
(Web) VerticalCardListFeature can't read video media

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
@@ -80,7 +80,9 @@ function VerticalCardListFeature(props = {}) {
           title={cards[0].title}
           summary={cards[0].summary}
           onClick={() => handleActionPress(cards[0])}
-          videoMedia={cards[0].relatedNode?.videos[0]}
+          videoMedia={
+            cards[0].relatedNode?.videos ? cards[0].relatedNode.videos[0] : null
+          }
           horizontal={true}
         />
       ) : (


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## ✏️ Description

This changes address a bug where `VerticalCardListFeature` would cause error due to trying to key into a undefined value
<!--
Describe your changes, and why you're making them. Is this linked to an open issue, a Trello card, or another pull request? Link it here.
-->

copilot:summary

## 🔬 To Test

1. Render a VerticalCardList with no media
2. Should no longer error out
3. I used this feature feed: 
 ```
<div
data-type="FeatureFeed"
      data-church="chase_oaks"
      data-feature-feed="FeatureFeed:bf42a9fe-33e4-4056-9ff2-dc583ec20941"
      data-modal="true"
      class="apollos-widget"></div>
```




## 📸 Screenshots
<img width="720" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/05c5e87e-7b2f-46e2-85d1-4b8f46029be1">

## 🧐 Detailed Changes

copilot:walkthrough

## ⚠️ To-do Before Merge

<!--
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Ensure PR #42 is merged
- [ ] Update Figma to reflect some design changes made in code
-->

## 📝 Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.
-->

- [ ] I have performed a self-review of my code
- [ ] I have tested my code works in the project (nothing breaks)
- [ ] I have commented my code in hard-to-understand areas
- [ ] New and existing tests and linting pass locally with my changes
- [ ] I have made corresponding changes to the documentation (new envs?)
- [ ] For PR's with design updates/changes, I have consulted with the product designer and made all necessary adjustments in Figma
