### PR TITLE
Fix share button

### DIFF
--- a/packages/web-shared/ui-kit/ShareButton/ShareButton.js
+++ b/packages/web-shared/ui-kit/ShareButton/ShareButton.js
@@ -16,9 +16,16 @@ const ShareButton = (props = {}) => {
   useEffect(() => {
     // Define event listener to handle clicks outside of message
     function handleClickOutside(event) {
+      // Check if the event target is the share button itself
+      const isShareButton = event.target.closest('button[title="Share"]');
+
       // Check if message is visible and click is outside of message
-      if (isMessageVisible && !event.target.closest('#menu')) {
-        // If both conditions are true, hide message by updating state
+      if (
+        isMessageVisible &&
+        !event.target.closest('#menu') &&
+        !isShareButton
+      ) {
+        // If all conditions are true, hide message by updating state
         setMessageVisible(false);
       }
     }
@@ -30,7 +37,7 @@ const ShareButton = (props = {}) => {
     return () => {
       document.removeEventListener('click', handleClickOutside);
     };
-  }, [isMessageVisible]);
+  });
 
   const link = window.location.href;
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## ✏️ Description
Before the useEffect code would instantly change the visibility of the share menu to false the second you clicked on the share button. This fixes that button to account for clicking on the share button to not close the share button. 
<!--
Describe your changes, and why you're making them. Is this linked to an open issue, a Trello card, or another pull request? Link it here.
-->

copilot:summary

## 🔬 To Test

1. Fire up the web-embeds
2. Click on share button make sure it works

## 📸 Screenshots

https://github.com/ApollosProject/apollos-embeds/assets/2528817/b162fda3-adbc-4aeb-81bb-6fedcadd9b6f


<!--
| Feature | Simulator | Figma | Links | Design Considerations |
| --- | --- | --- | --- | ---|
| Feature 1 | _attach image_ | _attach image_ | [Link to Figma](linkurl) | The reason that we chose to do... |
| Feature 2 | _attach image_ | _attach image_ | [Link to Figma](linkurl) | The reason that we chose to do... |
-->

## 🧐 Detailed Changes

copilot:walkthrough

## ⚠️ To-do Before Merge

<!--
Include any notes about things that need to happen before this PR is merged, e.g.:
- [ ] Ensure PR #42 is merged
- [ ] Update Figma to reflect some design changes made in code
-->

## 📝 Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.
-->

