### PR TITLE
Add transparency to buttonGroup buttons

### DIFF
--- a/packages/web-shared/ui-kit/ButtonGroup/ButtonGroup.styles.js
+++ b/packages/web-shared/ui-kit/ButtonGroup/ButtonGroup.styles.js
@@ -16,24 +16,27 @@ const ButtonGroup = withTheme(styled.div`
 const buttonState = ({ theme, type, disabled }) => {
   return css`
     &:hover {
-      background: ${themeGet('colors.neutral.gray5')};
+      opacity: 0.5;
+      background: ${themeGet('colors.fill.system1')};
     }
     &:disabled {
       opacity: 0.5;
       background: ${type === 'secondary'
         ? 'transparent'
-        : theme.colors.neutral.gray6};
+        : theme.colors.fill.system1};
       border: ${type === 'secondary' ? theme.colors.base.gray : 'transparent'};
       cursor: not-allowed;
     }
     &:hover &:disabled {
-      background: ${themeGet('colors.neutral.gray6')};
+      opacity: 0.5;
+      background: ${themeGet('colors.fill.system1')};
     }
   `;
 };
 
 const Button = withTheme(styled.button`
-  background: ${themeGet('colors.neutral.gray6')};
+  opacity: 0.8;
+  background: ${themeGet('colors.fill.system1')};
   padding: 10px;
   border-radius: 50%;
   border: 0;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## ✏️ Description
The goal of this adjustment is to add a little bit of flexibility to our carousel arrow buttons to look ok on more than just white backgrounds. This just the first step in making our web-embeds more flexible in regards to theming. It adjusts the color and adds a little bit of transparency.

https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6675487050
<!--
Describe your changes, and why you're making them. Is this linked to an open issue, a Trello card, or another pull request? Link it here.
-->

## 🔬 To Test

1. Open up the Vercel preview and make sure the carousel arrows look good on a white background and "Ok" on other background colors.

## 📸 Screenshots

<!--
| Feature | Simulator | Figma | Links | Design Considerations |
| --- | --- | --- | --- | ---|
| Feature 1 | _attach image_ | _attach image_ | [Link to Figma](linkurl) | The reason that we chose to do... |
| Feature 2 | _attach image_ | _attach image_ | [Link to Figma](linkurl) | The reason that we chose to do... |
-->
![image](https://github.com/ApollosProject/apollos-embeds/assets/2528817/2ad9bfbb-da16-452b-a7b8-f39fdf70fbc4)


https://github.com/ApollosProject/apollos-embeds/assets/2528817/a117cb7c-263e-422f-bfb2-5bc59b72c34c


## 📝 Checklist

<!--
This checklist is mostly useful as a reminder of small things that can easily be forgotten – it is meant as a helpful tool rather than hoops to jump through.

Put an `x` in all the items that apply, make notes next to any that haven't been addressed, and remove any items that are not relevant to this PR.
-->

- [x] I have performed a self-review of my code
- [x] I have tested my code works in the project (nothing breaks)
- [x] For PR's with design updates/changes, I have consulted with the product designer and made all necessary adjustments in Figma
