### PR TITLE
fix: series UI

### DIFF
--- a/packages/web-shared/components/ContentSeriesSingle.js
+++ b/packages/web-shared/components/ContentSeriesSingle.js
@@ -16,7 +16,7 @@ import {
   Loader,
   Longform,
   H3,
-  MediaItem,
+  ContentCard,
   ShareButton,
 } from '../ui-kit';
 import { useVideoMediaProgress } from '../hooks';
@@ -72,7 +72,6 @@ function ContentSeriesSingle(props = {}) {
   const title = props?.data?.title;
   const childContentItems = props.data?.childContentItemsConnection?.edges;
   const hasChildContent = childContentItems?.length > 0;
-  const showEpisodeCount = hasChildContent && childContentItems.length < 20;
 
   // Truncates text for long descriptions (can be adjusted by tweaking line-clamp and max-height values)
   const MultilineEllipsis = styled.p`
@@ -167,15 +166,7 @@ function ContentSeriesSingle(props = {}) {
               md: '0',
             }}
           >
-            <Box mb="xs">
-              {title ? <H2>{title}</H2> : null}
-              {showEpisodeCount ? (
-                <H5 color="text.secondary" mr="l">
-                  {childContentItems.length}{' '}
-                  {`Episode${childContentItems.length === 1 ? '' : 's'}`}
-                </H5>
-              ) : null}
-            </Box>
+            <Box mb="xs">{title ? <H2>{title}</H2> : null}</Box>
             {htmlContent ? (
               <Box mb="xs">
                 <MultilineEllipsis>
@@ -199,33 +190,38 @@ function ContentSeriesSingle(props = {}) {
 
         {/* Display content for series */}
         {hasChildContent ? (
-          <Box mb="l">
-            <H3 mb="xs">{props.feature?.title}</H3>
-            <Box
-              display="grid"
-              gridGap="30px"
-              gridTemplateColumns={{
-                _: 'repeat(1, minmax(0, 1fr));',
-                md: 'repeat(2, minmax(0, 1fr));',
-                lg: 'repeat(3, minmax(0, 1fr));',
-              }}
-              padding={{
-                _: '30px',
-                md: '0',
-              }}
-            >
-              {childContentItems?.map((item) => (
-                <MediaItem
-                  key={item.node?.title}
-                  image={item.node?.coverImage}
-                  title={item.node?.title}
-                  summary={item.node?.summary}
-                  onClick={() => handleActionPress(item.node)}
-                  videoMedia={item.node?.videos[0]}
-                />
-              ))}
+          <>
+            <H3 flex="1" mr="xs">
+              In This Series
+            </H3>
+            <Box mb="l">
+              <H3 mb="xs">{props.feature?.title}</H3>
+              <Box
+                display="grid"
+                gridGap="30px"
+                gridTemplateColumns={{
+                  _: 'repeat(1, minmax(0, 1fr));',
+                  md: 'repeat(2, minmax(0, 1fr));',
+                  lg: 'repeat(3, minmax(0, 1fr));',
+                }}
+                padding={{
+                  _: '30px',
+                  md: '0',
+                }}
+              >
+                {childContentItems?.map((item) => (
+                  <ContentCard
+                    key={item.node?.title}
+                    image={item.node?.coverImage}
+                    title={item.node?.title}
+                    summary={item.node?.summary}
+                    onClick={() => handleActionPress(item.node)}
+                    videoMedia={item.node?.videos[0]}
+                  />
+                ))}
+              </Box>
             </Box>
-          </Box>
+          </>
         ) : null}
       </Box>
     </>

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -21,7 +21,7 @@ import {
   Loader,
   Longform,
   H3,
-  MediaItem,
+  ContentCard,
   BodyText,
   ShareButton,
 } from '../ui-kit';
@@ -85,8 +85,6 @@ function ContentSingle(props = {}) {
     (feature) => FeatureFeedComponentMap[feature.__typename]
   );
   const hasFeatures = validFeatures?.length;
-  const showEpisodeCount = hasChildContent && childContentItems.length < 20;
-
   const publishDate = new Date(parseInt(props?.data?.publishDate));
 
   const formattedPublishDate = props?.data?.publishDate
@@ -195,13 +193,6 @@ function ContentSingle(props = {}) {
             </Box>
           </Box>
 
-          {/* Children Count */}
-          {showEpisodeCount ? (
-            <H4 color="text.secondary" mr="l">
-              {childContentItems.length}{' '}
-              {`Episode${childContentItems.length === 1 ? '' : 's'}`}
-            </H4>
-          ) : null}
           {htmlContent ? (
             <>
               <Longform
@@ -230,16 +221,19 @@ function ContentSingle(props = {}) {
                 md: '0',
               }}
             >
-              {childContentItems?.map((item, index) => (
-                <MediaItem
-                  key={item.node?.title}
-                  image={item.node?.coverImage}
-                  title={item.node?.title}
-                  summary={item.node?.summary}
-                  onClick={() => handleActionPress(item.node)}
-                  videoMedia={item.node?.videos[0]}
-                />
-              ))}
+              {childContentItems?.map(
+                (item, index) =>
+                  console.log('item', item) || (
+                    <ContentCard
+                      key={item.node?.title}
+                      image={item.node?.coverImage}
+                      title={item.node?.title}
+                      summary={item.node?.summary}
+                      onClick={() => handleActionPress(item.node)}
+                      videoMedia={item.node?.videos[0]}
+                    />
+                  )
+              )}
             </Box>
           </Box>
         ) : null}
@@ -261,7 +255,7 @@ function ContentSingle(props = {}) {
               }}
             >
               {siblingContentItems?.map((item, index) => (
-                <MediaItem
+                <ContentCard
                   key={item.node?.title}
                   image={item.node?.coverImage}
                   title={item.node?.title}

--- a/packages/web-shared/components/InformationalContentSingle.js
+++ b/packages/web-shared/components/InformationalContentSingle.js
@@ -85,7 +85,6 @@ function InformationalContentSingle(props = {}) {
     (feature) => FeatureFeedComponentMap[feature.__typename]
   );
   const hasFeatures = validFeatures?.length;
-  const showEpisodeCount = hasChildContent && childContentItems.length < 20;
 
   const publishDate = new Date(parseInt(props?.data?.publishDate));
 
@@ -207,13 +206,6 @@ function InformationalContentSingle(props = {}) {
             </Box>
           </Box>
 
-          {/* Children Count */}
-          {showEpisodeCount ? (
-            <H4 color="text.secondary" mr="l">
-              {childContentItems.length}{' '}
-              {`Episode${childContentItems.length === 1 ? '' : 's'}`}
-            </H4>
-          ) : null}
           {htmlContent ? (
             <>
               <Longform

--- a/packages/web-shared/components/LivestreamSingle.js
+++ b/packages/web-shared/components/LivestreamSingle.js
@@ -25,8 +25,6 @@ import {
 import { useVideoMediaProgress, useLivestreamStatus } from '../hooks';
 import VideoPlayer from './VideoPlayer';
 
-const MAX_EPISODE_COUNT = 20;
-
 function LivestreamSingle(props = {}) {
   const navigate = useNavigate();
 
@@ -78,8 +76,6 @@ function LivestreamSingle(props = {}) {
     (feature) => FeatureFeedComponentMap[feature.__typename]
   );
   const hasFeatures = validFeatures?.length;
-  const showEpisodeCount =
-    hasChildContent && childContentItems.length < MAX_EPISODE_COUNT;
 
   const publishDate = new Date(parseInt(props?.data?.publishDate));
 
@@ -162,13 +158,6 @@ function LivestreamSingle(props = {}) {
             </Box>
           </Box>
 
-          {/* Children Count */}
-          {showEpisodeCount ? (
-            <H4 color="text.secondary" mr="xl">
-              {childContentItems.length}{' '}
-              {`Episode${childContentItems.length === 1 ? '' : 's'}`}
-            </H4>
-          ) : null}
           {htmlContent ? (
             <>
               <Longform dangerouslySetInnerHTML={{ __html: sanitizedHTML }} />

--- a/packages/web-shared/embeds/FeatureFeed.js
+++ b/packages/web-shared/embeds/FeatureFeed.js
@@ -24,17 +24,27 @@ function RenderFeatures(props) {
 
   switch (type) {
     case 'EventContentItem':
-    case 'InformationalContentItem':
     case 'MediaContentItem':
     case 'WeekendContentItem':
-    case 'UniversalContentItem':
-    case 'ContentSeriesContentItem': {
+    case 'UniversalContentItem': {
       const options = {
         variables: { id: `${type}:${randomId}` },
       };
 
       return (
         <ContentItemProvider Component={ContentSingle} options={options} />
+      );
+    }
+    case 'ContentSeriesContentItem': {
+      const options = {
+        variables: { id: `${type}:${randomId}` },
+      };
+
+      return (
+        <ContentItemProvider
+          Component={ContentSeriesSingle}
+          options={options}
+        />
       );
     }
     case 'Livestream': {

--- a/packages/web-shared/embeds/Search.js
+++ b/packages/web-shared/embeds/Search.js
@@ -30,17 +30,27 @@ function RenderFeatures(props) {
 
   switch (type) {
     case 'EventContentItem':
-    case 'InformationalContentItem':
     case 'MediaContentItem':
     case 'WeekendContentItem':
-    case 'UniversalContentItem':
-    case 'ContentSeriesContentItem': {
+    case 'UniversalContentItem': {
       const options = {
         variables: { id: `${type}:${randomId}` },
       };
 
       return (
         <ContentItemProvider Component={ContentSingle} options={options} />
+      );
+    }
+    case 'ContentSeriesContentItem': {
+      const options = {
+        variables: { id: `${type}:${randomId}` },
+      };
+
+      return (
+        <ContentItemProvider
+          Component={ContentSeriesSingle}
+          options={options}
+        />
       );
     }
     case 'Livestream': {

--- a/packages/web-shared/hooks/useContentItem.js
+++ b/packages/web-shared/hooks/useContentItem.js
@@ -47,6 +47,7 @@ export const GET_CONTENT_ITEM = gql`
             node {
               id
               title
+              summary
               coverImage {
                 sources {
                   uri
@@ -63,6 +64,7 @@ export const GET_CONTENT_ITEM = gql`
             node {
               id
               title
+              summary
               coverImage {
                 sources {
                   uri


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Liquid requested layout changes to web-embeds for their series content.

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

I adjusted the web-embeds series layout and updated some configuration of their app to accommodate their requests, while not straying away from what is best for the product.

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Check out the Spartan Faith Series. The hero has a new layout and the child items are content cards.
https://apollos-web-embeds-git-fix-series-ui-apollos-embeds.vercel.app/?id=ContentSeriesContentItem-ed5f1375-faa7-4e33-9bfe-028f25c5ac57
2. Check out one of the items in the Spartan Faith Series. The child items are present now and the items are content cards. 

Note: To get the child/sibling items to show up I had to update the ROCK.CONFIG in Retool for Liquid and then run a backfill on the Rock content dag.

## 📸 Screenshots


| Before | After |
| --- | --- |
| <img width="1279" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/8549d219-a114-4310-a347-728a594cbd05"> | <img width="1302" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/e2211911-3503-4609-bbb7-5d458df18d83">|
| <img width="970" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/4abf58fd-80cf-4d03-9cc9-c7f21688e139"> |<img width="851" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/78c44ebc-2871-45f6-932a-7adab48014a7">|


