### PR TITLE
Feat search section headers and hitting enter on keyboard

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -247,15 +247,6 @@ export default function Autocomplete({
     inputRef.current?.[autocompleteState.isOpen ? 'blur' : 'focus']();
   };
 
-  // (Desktop Specific Behavior): Hitting enter scrolls dropdown to results
-  const scrollToResults = (event) => {
-    const resultsElement = document.getElementById('results');
-    event.preventDefault();
-    if (resultsElement) {
-      resultsElement.scrollIntoView({ behavior: 'smooth' });
-    }
-  };
-
   // Query Suggesion Index Definition
   const querySuggestionsPlugin = createQuerySuggestionsPlugin({
     searchClient,
@@ -379,7 +370,7 @@ export default function Autocomplete({
     autocomplete.setIsOpen(true);
     autocomplete.refresh();
   };
-  formProps.onSubmit = scrollToResults;
+
   containerProps['aria-labelledby'] = autoCompleteLabel;
   inputProps['aria-labelledby'] = autoCompleteLabel;
   panelProps['aria-labelledby'] = autoCompleteLabel;

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -446,6 +446,17 @@ export default function Autocomplete({
             ) {
               return (
                 <div key={`source-${index}`} className="aa-Source">
+                  {collection.source.sourceId === 'querySuggestionsPlugin' &&
+                    !inputProps.value && (
+                      <Box padding="xs" fontWeight="600" color="base.gray">
+                        Trending Searches
+                      </Box>
+                    )}
+                  {collection.source.sourceId === 'recentSearchesPlugin' && (
+                    <Box padding="xs" fontWeight="600" color="base.gray">
+                      Search History
+                    </Box>
+                  )}
                   <ul className="aa-List" {...autocomplete.getListProps()}>
                     {items.map((item, index) => (
                       <li

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -238,6 +238,20 @@ export default function Autocomplete({
     autocomplete.refresh();
   };
 
+  const handleEnterKeySubmit = (event) => {
+    event.preventDefault();
+    const value = inputProps.value;
+    if (value) {
+      recentSearchesPlugin.data.addItem({
+        id: value,
+        label: value,
+        _highLightResult: { label: { value: value } },
+      });
+      autocomplete.setQuery(value);
+    }
+    autocomplete.refresh();
+  };
+
   const handlePanelDropdown = () => {
     const updatedAutocompleteState = { ...autocompleteState };
     updatedAutocompleteState.isOpen = !updatedAutocompleteState.isOpen;
@@ -370,7 +384,7 @@ export default function Autocomplete({
     autocomplete.setIsOpen(true);
     autocomplete.refresh();
   };
-
+  formProps.onSubmit = handleEnterKeySubmit;
   containerProps['aria-labelledby'] = autoCompleteLabel;
   inputProps['aria-labelledby'] = autoCompleteLabel;
   panelProps['aria-labelledby'] = autoCompleteLabel;


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
User feedback stated that search sections were confusing and adding section headers would help clarify what each section was.

Also, went ahead and fixed this issue while I was in the autocomplete file. https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6655702888

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
This PR adds "Trending Searches" and "Search History" titles to the Algolia search sections. 

When a user hits enter on the keyboard the value is added to the search history and set as the query value.

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Open up the search functionality
2. With nothing in search a user should see the title "Trending Searches", once they type something the "autocomplete" Algolia functionality takes over and that header is hidden.
3. If a user has search history they will now see a section header above those items
4.  One extra item that was fixed was that when you click enter the screen no longer scrolls down and sets the input value as the query and saves it to the search history. Users reported that felt like a bug when it scrolled, it also caused problems on mobile devices as it scrolled to the wrong place.

## 📸 Screenshots

Video of hitting enter and input value saving to search history.
https://github.com/ApollosProject/apollos-embeds/assets/2528817/f4fd15aa-c5d4-46c3-87ac-3f4c61361a48



| Before | After |
| --- | --- |
| <img width="740" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/62e7bbef-077f-4e40-a015-0624e057ea71"> | <img width="738" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/b7ccda06-bcb0-40b6-b87c-5ac8a2ec953a"> |
