### PR TITLE
Create apple-app-site-association

### DIFF
--- a/micro-service/public/.well-known/apple-app-site-association
+++ b/micro-service/public/.well-known/apple-app-site-association
@@ -1,0 +1,14 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "7KS82J74VW.com.differential.apollospreview",
+        "paths": ["*"]
+      }
+    ]
+  },
+  "activitycontinuation": {
+    "apps": ["7KS82J74VW.com.differential.apollospreview"]
+  }
+}


### PR DESCRIPTION


## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
This allows Apollos Preview to scan QR code links from Admin.



## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Will eventually add support to have QR code links open in church's official app instead of Apollos Preview - but that's going to take making this .well-known file dynamically generated based on the sub-domain, and want to test with the wildcard setup first on regular Apollos Preview

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. verify that this file loads when visiting /.well-known/apple-app-site-association

## 📸 Screenshots

<!--
| Before | After |
| --- | --- |
| _attach image_ | _attach image_ |
| _attach image_ | _attach image_ |
-->
