### PR TITLE
Remove publish date from content items

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import format from 'date-fns/format';
-import addMinutes from 'date-fns/addMinutes';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getURLFromType, parseDescriptionLinks } from '../utils';
@@ -85,14 +83,6 @@ function ContentSingle(props = {}) {
     (feature) => FeatureFeedComponentMap[feature.__typename]
   );
   const hasFeatures = validFeatures?.length;
-  const publishDate = new Date(parseInt(props?.data?.publishDate));
-
-  const formattedPublishDate = props?.data?.publishDate
-    ? format(
-        addMinutes(publishDate, publishDate.getTimezoneOffset()),
-        'MMMM do, yyyy'
-      )
-    : null;
 
   // We'll conditionally place this divider as needed
   const infoDivider = (
@@ -171,14 +161,6 @@ function ContentSingle(props = {}) {
                     mb={title && !hasChildContent ? 'xxs' : ''}
                   >
                     {parentChannel.name}
-                  </BodyText>
-                ) : null}
-
-                {/* ( Optional Divider ) */}
-                {formattedPublishDate ? infoDivider : null}
-                {formattedPublishDate ? (
-                  <BodyText color="text.secondary">
-                    {formattedPublishDate}
                   </BodyText>
                 ) : null}
               </Box>
@@ -291,7 +273,6 @@ ContentSingle.propTypes = {
       id: PropTypes.string,
       name: PropTypes.string,
     }),
-    publishDate: PropTypes.string,
     summary: PropTypes.string,
     title: PropTypes.string,
     videos: PropTypes.arrayOf(PropTypes.shape({ embedHtml: PropTypes.string })),

--- a/packages/web-shared/components/InformationalContentSingle.js
+++ b/packages/web-shared/components/InformationalContentSingle.js
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import format from 'date-fns/format';
-import addMinutes from 'date-fns/addMinutes';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getURLFromType, parseDescriptionLinks } from '../utils';
@@ -86,15 +84,6 @@ function InformationalContentSingle(props = {}) {
   );
   const hasFeatures = validFeatures?.length;
 
-  const publishDate = new Date(parseInt(props?.data?.publishDate));
-
-  const formattedPublishDate = props?.data?.publishDate
-    ? format(
-        addMinutes(publishDate, publishDate.getTimezoneOffset()),
-        'MMMM do, yyyy'
-      )
-    : null;
-
   // We'll conditionally place this divider as needed
   const infoDivider = (
     <BodyText color="text.tertiary" mx="xs">
@@ -147,14 +136,6 @@ function InformationalContentSingle(props = {}) {
                   mb={title && !hasChildContent ? 'xxs' : ''}
                 >
                   {parentChannel.name}
-                </BodyText>
-              ) : null}
-
-              {/* ( Optional Divider ) */}
-              {formattedPublishDate ? infoDivider : null}
-              {formattedPublishDate ? (
-                <BodyText color="text.secondary">
-                  {formattedPublishDate}
                 </BodyText>
               ) : null}
             </Box>
@@ -300,7 +281,6 @@ InformationalContentSingle.propTypes = {
       id: PropTypes.string,
       name: PropTypes.string,
     }),
-    publishDate: PropTypes.string,
     summary: PropTypes.string,
     title: PropTypes.string,
     videos: PropTypes.arrayOf(PropTypes.shape({ embedHtml: PropTypes.string })),

--- a/packages/web-shared/components/LivestreamSingle.js
+++ b/packages/web-shared/components/LivestreamSingle.js
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import DOMPurify from 'dompurify';
-import format from 'date-fns/format';
-import addMinutes from 'date-fns/addMinutes';
 import { useNavigate } from 'react-router-dom';
 
 import { getURLFromType } from '../utils';
@@ -77,15 +75,6 @@ function LivestreamSingle(props = {}) {
   );
   const hasFeatures = validFeatures?.length;
 
-  const publishDate = new Date(parseInt(props?.data?.publishDate));
-
-  const formattedPublishDate = props?.data?.publishDate
-    ? format(
-        addMinutes(publishDate, publishDate.getTimezoneOffset()),
-        'MMMM do, yyyy'
-      )
-    : null;
-
   const sanitizedHTML = DOMPurify.sanitize(htmlContent);
 
   // We'll conditionally place this divider as needed
@@ -143,14 +132,6 @@ function LivestreamSingle(props = {}) {
                 >
                   Livestream
                 </BodyText>
-
-                {/* ( Optional Divider ) */}
-                {formattedPublishDate ? infoDivider : null}
-                {formattedPublishDate ? (
-                  <BodyText color="text.secondary">
-                    {formattedPublishDate}
-                  </BodyText>
-                ) : null}
               </Box>
             </Box>
             <Box>
@@ -206,7 +187,6 @@ LivestreamSingle.propTypes = {
     featureFeed: PropTypes.shape({}),
     htmlContent: PropTypes.string,
     id: PropTypes.string,
-    publishDate: PropTypes.string,
     summary: PropTypes.string,
     title: PropTypes.string,
     videos: PropTypes.arrayOf(PropTypes.shape({ embedHtml: PropTypes.string })),

--- a/packages/web-shared/components/VideoPlayer/VideoPlayer.js
+++ b/packages/web-shared/components/VideoPlayer/VideoPlayer.js
@@ -253,7 +253,6 @@ VideoPlayer.propTypes = {
   dangerouslySetInnerHTML: PropTypes.string,
   parentNode: PropTypes.shape({
     id: PropTypes.string,
-    publishDate: PropTypes.string,
     summary: PropTypes.string,
     title: PropTypes.string,
     videos: PropTypes.arrayOf(VideoMedia),

--- a/packages/web-shared/hooks/useContentItem.js
+++ b/packages/web-shared/hooks/useContentItem.js
@@ -25,7 +25,6 @@ export const GET_CONTENT_ITEM = gql`
         }
       }
       ... on ContentItem {
-        publishDate
         title
         originId
         htmlContent


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Publish dates are not relevant to content items and we don't have them on mobile. Customers are sharing feedback that the dates are not helpful and are launch blocking if they are not removed.

## ✏️ Solution
Remove dates from content items
<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. https://apollos-web-embeds-git-remove-dates-conte-fe8317-apollos-embeds.vercel.app/?id=UniversalContentItem-b7896d20-34dc-45a1-9739-e8e4a7793a73 Dates are removed

## 📸 Screenshots


| Before | After |
| --- | --- |
|<img width="1334" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/e1587a2c-46f4-4b17-bee5-e0d5ca20c1f9">|<img width="1335" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/f5dedcf1-7fa2-4f63-b5d1-ac2445100ad8">|

