### PR TITLE
Remove pages content titles and update "No results Found"

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -205,37 +205,42 @@ function ContentSingle(props = {}) {
         </Box>
         {/* Display content for series */}
         {hasChildContent ? (
-          <Box mb="l">
-            <H3 mb="xs">{props.feature?.title}</H3>
+          <>
+            <H3 flex="1" mr="xs">
+              In This Series
+            </H3>
+            <Box mb="l">
+              <H3 mb="xs">{props.feature?.title}</H3>
 
-            <Box
-              display="grid"
-              gridGap="30px"
-              gridTemplateColumns={{
-                _: 'repeat(1, minmax(0, 1fr));',
-                md: 'repeat(2, minmax(0, 1fr));',
-                lg: 'repeat(3, minmax(0, 1fr));',
-              }}
-              padding={{
-                _: '30px',
-                md: '0',
-              }}
-            >
-              {childContentItems?.map(
-                (item, index) =>
-                  console.log('item', item) || (
-                    <ContentCard
-                      key={item.node?.title}
-                      image={item.node?.coverImage}
-                      title={item.node?.title}
-                      summary={item.node?.summary}
-                      onClick={() => handleActionPress(item.node)}
-                      videoMedia={item.node?.videos[0]}
-                    />
-                  )
-              )}
+              <Box
+                display="grid"
+                gridGap="30px"
+                gridTemplateColumns={{
+                  _: 'repeat(1, minmax(0, 1fr));',
+                  md: 'repeat(2, minmax(0, 1fr));',
+                  lg: 'repeat(3, minmax(0, 1fr));',
+                }}
+                padding={{
+                  _: '30px',
+                  md: '0',
+                }}
+              >
+                {childContentItems?.map(
+                  (item, index) =>
+                    console.log('item', item) || (
+                      <ContentCard
+                        key={item.node?.title}
+                        image={item.node?.coverImage}
+                        title={item.node?.title}
+                        summary={item.node?.summary}
+                        onClick={() => handleActionPress(item.node)}
+                        videoMedia={item.node?.videos[0]}
+                      />
+                    )
+                )}
+              </Box>
             </Box>
-          </Box>
+          </>
         ) : null}
         {/* Display content for sermons */}
         {hasSiblingContent ? (

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -205,42 +205,37 @@ function ContentSingle(props = {}) {
         </Box>
         {/* Display content for series */}
         {hasChildContent ? (
-          <>
-            <H3 flex="1" mr="xs">
-              In This Series
-            </H3>
-            <Box mb="l">
-              <H3 mb="xs">{props.feature?.title}</H3>
+          <Box mb="l">
+            <H3 mb="xs">{props.feature?.title}</H3>
 
-              <Box
-                display="grid"
-                gridGap="30px"
-                gridTemplateColumns={{
-                  _: 'repeat(1, minmax(0, 1fr));',
-                  md: 'repeat(2, minmax(0, 1fr));',
-                  lg: 'repeat(3, minmax(0, 1fr));',
-                }}
-                padding={{
-                  _: '30px',
-                  md: '0',
-                }}
-              >
-                {childContentItems?.map(
-                  (item, index) =>
-                    console.log('item', item) || (
-                      <ContentCard
-                        key={item.node?.title}
-                        image={item.node?.coverImage}
-                        title={item.node?.title}
-                        summary={item.node?.summary}
-                        onClick={() => handleActionPress(item.node)}
-                        videoMedia={item.node?.videos[0]}
-                      />
-                    )
-                )}
-              </Box>
+            <Box
+              display="grid"
+              gridGap="30px"
+              gridTemplateColumns={{
+                _: 'repeat(1, minmax(0, 1fr));',
+                md: 'repeat(2, minmax(0, 1fr));',
+                lg: 'repeat(3, minmax(0, 1fr));',
+              }}
+              padding={{
+                _: '30px',
+                md: '0',
+              }}
+            >
+              {childContentItems?.map(
+                (item, index) =>
+                  console.log('item', item) || (
+                    <ContentCard
+                      key={item.node?.title}
+                      image={item.node?.coverImage}
+                      title={item.node?.title}
+                      summary={item.node?.summary}
+                      onClick={() => handleActionPress(item.node)}
+                      videoMedia={item.node?.videos[0]}
+                    />
+                  )
+              )}
             </Box>
-          </>
+          </Box>
         ) : null}
         {/* Display content for sermons */}
         {hasSiblingContent ? (

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -177,7 +177,7 @@ export default function Autocomplete({
   const dispatchBreadcrumb = useBreadcrumbDispatch();
   const [state, dispatch] = useModal();
 
-  const [isPagesAndContentEmpty, setIsPagesAndContentEmpty] = useState(false);
+  const [isResultsEmpty, setIsResultsEmpty] = useState(false);
 
   const handleActionPress = (item) => {
     if (searchParams.get('id') !== getURLFromType(item)) {
@@ -433,9 +433,7 @@ export default function Autocomplete({
         (collection) => collection.source.sourceId === 'content'
       )?.items || [];
 
-    setIsPagesAndContentEmpty(
-      pagesItems.length === 0 && contentItems.length === 0
-    );
+    setIsResultsEmpty(pagesItems.length === 0 && contentItems.length === 0);
   }, [autocompleteState.collections]);
 
   // ...CUSTOM RENDERER
@@ -458,7 +456,7 @@ export default function Autocomplete({
         {...autocomplete.getPanelProps({})}
       >
         {autocompleteState.isOpen && <div id="panel-top"></div>}
-        {isPagesAndContentEmpty &&
+        {isResultsEmpty &&
           autocompleteState.collections.some((collection) =>
             ['pages', 'content'].includes(collection.source.sourceId)
           ) && (

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -1,5 +1,6 @@
 import React, {
   useEffect,
+  useState,
   useRef,
   useMemo,
   createElement,
@@ -175,6 +176,8 @@ export default function Autocomplete({
   const [searchParams, setSearchParams] = useSearchParams();
   const dispatchBreadcrumb = useBreadcrumbDispatch();
   const [state, dispatch] = useModal();
+
+  const [isPagesAndContentEmpty, setIsPagesAndContentEmpty] = useState(false);
 
   const handleActionPress = (item) => {
     if (searchParams.get('id') !== getURLFromType(item)) {
@@ -420,6 +423,21 @@ export default function Autocomplete({
     };
   }, [autocompleteState.isOpen, autocomplete, setShowTextPrompt]);
 
+  useEffect(() => {
+    const pagesItems =
+      autocompleteState.collections.find(
+        (collection) => collection.source.sourceId === 'pages'
+      )?.items || [];
+    const contentItems =
+      autocompleteState.collections.find(
+        (collection) => collection.source.sourceId === 'content'
+      )?.items || [];
+
+    setIsPagesAndContentEmpty(
+      pagesItems.length === 0 && contentItems.length === 0
+    );
+  }, [autocompleteState.collections]);
+
   // ...CUSTOM RENDERER
   return (
     <div className="aa-Autocomplete" {...containerProps}>
@@ -440,6 +458,20 @@ export default function Autocomplete({
         {...autocomplete.getPanelProps({})}
       >
         {autocompleteState.isOpen && <div id="panel-top"></div>}
+        {isPagesAndContentEmpty &&
+          autocompleteState.collections.some((collection) =>
+            ['pages', 'content'].includes(collection.source.sourceId)
+          ) && (
+            <Box
+              padding="xs"
+              fontWeight="500"
+              color="base.gray"
+              textAlign="center"
+              fontStyle="italic"
+            >
+              No results found
+            </Box>
+          )}
         {autocompleteState.isOpen &&
           autocompleteState.collections.map((collection, index) => {
             const { source, items } = collection;
@@ -505,47 +537,36 @@ export default function Autocomplete({
             }
 
             // Rendering of regular items
+
             return autocompleteState.query !== '' ? (
               <div key={`source-${index}`} className="aa-Source">
-                {items.length > 0 ? (
-                  <ul className="aa-List" {...autocomplete.getListProps()}>
-                    {items.map((item) => (
-                      <Box
-                        as="li"
-                        borderRadius="0"
-                        padding="0"
-                        key={item.objectID}
-                        className="aa-Item"
-                        {...autocomplete.getItemProps({
-                          item,
-                          source,
-                        })}
-                      >
-                        <ResourceCard
-                          leadingAsset={item?.coverImage}
-                          title={item?.title}
-                          onClick={() => {
-                            if (collection.source.sourceId === 'pages') {
-                              return handleStaticActionPress(item);
-                            }
-                            return handleActionPress(item);
-                          }}
-                          background="none"
-                        />
-                      </Box>
-                    ))}
-                  </ul>
-                ) : (
-                  <Box
-                    padding="xs"
-                    fontWeight="500"
-                    color="base.gray"
-                    textAlign="center"
-                    fontStyle="italic"
-                  >
-                    No results found
-                  </Box>
-                )}
+                <ul className="aa-List" {...autocomplete.getListProps()}>
+                  {items.map((item) => (
+                    <Box
+                      as="li"
+                      borderRadius="0"
+                      padding="0"
+                      key={item.objectID}
+                      className="aa-Item"
+                      {...autocomplete.getItemProps({
+                        item,
+                        source,
+                      })}
+                    >
+                      <ResourceCard
+                        leadingAsset={item?.coverImage}
+                        title={item?.title}
+                        onClick={() => {
+                          if (collection.source.sourceId === 'pages') {
+                            return handleStaticActionPress(item);
+                          }
+                          return handleActionPress(item);
+                        }}
+                        background="none"
+                      />
+                    </Box>
+                  ))}
+                </ul>
               </div>
             ) : null;
           })}

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -507,21 +507,6 @@ export default function Autocomplete({
             // Rendering of regular items
             return autocompleteState.query !== '' ? (
               <div key={`source-${index}`} className="aa-Source">
-                {collection.source.sourceId === 'content' && (
-                  <Box
-                    padding="xs"
-                    fontWeight="600"
-                    color="base.gray"
-                    id="results"
-                  >
-                    Content
-                  </Box>
-                )}
-                {collection.source.sourceId === 'pages' && (
-                  <Box padding="xs" fontWeight="600" color="base.gray">
-                    Pages
-                  </Box>
-                )}
                 {items.length > 0 ? (
                   <ul className="aa-List" {...autocomplete.getListProps()}>
                     {items.map((item) => (


### PR DESCRIPTION
## 🐛 Issue/Solution

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

There was confusion around what the search titles were for 'pages' and 'content' so this PR removes those. But that also meant that we needed to update "No results found" to only so up once instead of twice. One for each index or collection of results coming from Algolia


## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Play around with search and make sure the page and content results display in a pleasing way and make sure the "No results found" only shows up once and when there are no results.
2. Also check the performance of the useEffect, I'm not sure if that is ok. There might be a better way to check for any results coming back.

## 📸 Screenshots

| Before | After |
| ---| --- |
|<img width="1104" alt="Xnapper-2023-11-29-15 52 24" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/edaf1280-ed16-4953-9b4e-ee8b212c475b"> |<img width="1256" alt="Xnapper-2023-11-29-15 51 25" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/9d1a4ad3-18ad-4f08-aa8d-f6cb2d2b9a33">|

