### PR TITLE
feat: add series title to sibling items on ContentSingle

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -205,40 +205,7 @@ function ContentSingle(props = {}) {
                 md: '0',
               }}
             >
-              {childContentItems?.map(
-                (item, index) =>
-                  console.log('item', item) || (
-                    <ContentCard
-                      key={item.node?.title + index}
-                      image={item.node?.coverImage}
-                      title={item.node?.title}
-                      summary={item.node?.summary}
-                      onClick={() => handleActionPress(item.node)}
-                      videoMedia={item.node?.videos[0]}
-                    />
-                  ),
-              )}
-            </Box>
-          </Box>
-        ) : null}
-        {/* Display content for sermons */}
-        {hasSiblingContent ? (
-          <Box mb="l">
-            <H3 mb="xs">{props.feature?.title}</H3>
-            <Box
-              display="grid"
-              gridGap="30px"
-              gridTemplateColumns={{
-                _: 'repeat(1, minmax(0, 1fr));',
-                md: 'repeat(2, minmax(0, 1fr));',
-                lg: 'repeat(3, minmax(0, 1fr));',
-              }}
-              padding={{
-                _: '30px',
-                md: '0',
-              }}
-            >
-              {siblingContentItems?.map((item, index) => (
+              {childContentItems?.map((item, index) => (
                 <ContentCard
                   key={item.node?.title + index}
                   image={item.node?.coverImage}
@@ -250,6 +217,41 @@ function ContentSingle(props = {}) {
               ))}
             </Box>
           </Box>
+        ) : null}
+        {/* Display content for sermons */}
+        {hasSiblingContent ? (
+          <>
+            <H3 flex="1" mr="xs">
+              In This Series
+            </H3>
+            <Box mb="l">
+              <H3 mb="xs">{props.feature?.title}</H3>
+              <Box
+                display="grid"
+                gridGap="30px"
+                gridTemplateColumns={{
+                  _: 'repeat(1, minmax(0, 1fr));',
+                  md: 'repeat(2, minmax(0, 1fr));',
+                  lg: 'repeat(3, minmax(0, 1fr));',
+                }}
+                padding={{
+                  _: '30px',
+                  md: '0',
+                }}
+              >
+                {siblingContentItems?.map((item, index) => (
+                  <ContentCard
+                    key={item.node?.title + index}
+                    image={item.node?.coverImage}
+                    title={item.node?.title}
+                    summary={item.node?.summary}
+                    onClick={() => handleActionPress(item.node)}
+                    videoMedia={item.node?.videos[0]}
+                  />
+                ))}
+              </Box>
+            </Box>
+          </>
         ) : null}
 
         {/* Sub-Feature Feed */}


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Request from Liquid

https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6675478428

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Adds "In this series" to content single sibling items and removes a console.log

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Check content item with siblings, it should have a title that says "In this series"

## 📸 Screenshots

<!--
| Before | After |
| --- | --- |
| _attach image_ | _attach image_ |
| _attach image_ | _attach image_ |
-->
<img width="940" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/60719291-b9f9-4af5-b4c9-01d5adc6f3c9">

