### PR TITLE
Update handleActionPress in hero feature to handle breadcrumbs

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -2,26 +2,10 @@ import React from 'react';
 import { withTheme } from 'styled-components';
 import { useSearchParams } from 'react-router-dom';
 import { getURLFromType } from '../../../utils';
-import {
-  open as openModal,
-  set as setModal,
-  useModal,
-} from '../../../providers/ModalProvider';
-import {
-  add as addBreadcrumb,
-  useBreadcrumbDispatch,
-} from '../../../providers/BreadcrumbProvider';
+import { open as openModal, set as setModal, useModal } from '../../../providers/ModalProvider';
+import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../../providers/BreadcrumbProvider';
 
-import {
-  BodyText,
-  Box,
-  Button,
-  H2,
-  H3,
-  H4,
-  systemPropTypes,
-  ContentCard,
-} from '../../../ui-kit';
+import { BodyText, Box, Button, H2, H3, H4, systemPropTypes, ContentCard } from '../../../ui-kit';
 import Styled from './HeroListFeature.styles';
 import { useNavigate } from 'react-router-dom';
 
@@ -32,6 +16,15 @@ function HeroListFeature(props = {}) {
   const navigate = useNavigate();
 
   const handleActionPress = (item) => {
+    if (searchParams.get('id') !== getURLFromType(item.relatedNode)) {
+      dispatchBreadcrumb(
+        addBreadcrumb({
+          url: `?id=${getURLFromType(item.relatedNode)}`,
+          title: item.relatedNode?.title,
+        })
+      );
+      setSearchParams(`?id=${getURLFromType(item.relatedNode)}`);
+    }
     navigate({
       pathname: '/',
       search: `?id=${getURLFromType(item.relatedNode)}`,
@@ -40,19 +33,14 @@ function HeroListFeature(props = {}) {
 
   // Event Handlers
   const handleHeroCardPress = () => {
-    if (
-      searchParams.get('id') !==
-      getURLFromType(props.feature?.heroCard?.relatedNode)
-    ) {
+    if (searchParams.get('id') !== getURLFromType(props.feature?.heroCard?.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(props.feature?.heroCard?.relatedNode)}`,
           title: props.feature?.heroCard?.relatedNode?.title,
         })
       );
-      setSearchParams(
-        `?id=${getURLFromType(props.feature?.heroCard?.relatedNode)}`
-      );
+      setSearchParams(`?id=${getURLFromType(props.feature?.heroCard?.relatedNode)}`);
     }
 
     if (state.modal) {
@@ -63,9 +51,7 @@ function HeroListFeature(props = {}) {
   };
 
   const handlePrimaryActionClick = () => {
-    setSearchParams(
-      `?id=${getURLFromType(props.feature.primaryAction.relatedNode)}`
-    );
+    setSearchParams(`?id=${getURLFromType(props.feature.primaryAction.relatedNode)}`);
   };
 
   const actions = props.feature?.actions;
@@ -76,12 +62,7 @@ function HeroListFeature(props = {}) {
       <Box>
         {/* List Header */}
         {props.feature.title || props.feature.subtitle ? (
-          <Box
-            flexDirection="row"
-            justifyContent="space-between"
-            alignItems="flex-end"
-            mb="s"
-          >
+          <Box flexDirection="row" justifyContent="space-between" alignItems="flex-end" mb="s">
             <Box>
               <H4 color="text.secondary">{props.feature.subtitle}</H4>
               <H3>{props.feature.title}</H3>
@@ -122,9 +103,7 @@ function HeroListFeature(props = {}) {
           padding={{ _: 'base', md: 'none' }}
           backdropFilter="blur(64px)"
         >
-          <Styled.Title mb="xxs">
-            {props?.feature?.heroCard?.title}
-          </Styled.Title>
+          <Styled.Title mb="xxs">{props?.feature?.heroCard?.title}</Styled.Title>
           <Styled.Summary color="text.secondary">
             {props?.feature?.heroCard?.summary}
           </Styled.Summary>


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6797509823

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

Add breadcrumb functionality to the hero feature `handleActionPress`

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Click on an action item in a hero feature list it should have breadcrumbs

![CleanShot 2023-12-01 at 15 28 38](https://github.com/ApollosProject/apollos-embeds/assets/2528817/768273ad-963b-4595-81b5-6d883f412609)



## 📸 Screenshots

| Before | After |
| --- | --- |
|<img width="1012" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/8c78a4eb-8b4d-4d84-b23a-23e98370706e">|<img width="1061" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/01e66333-ddc2-4baf-8073-4bdd648fbec0">|

