### PR TITLE
Improve HeroList typography styles

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -102,9 +102,14 @@ function HeroListFeature(props = {}) {
           width={{ _: 'auto', md: '40%' }}
           padding={{ _: 'base', md: 'none' }}
           backdropFilter="blur(64px)"
+          display="flex"
+          flexDirection="column"
+          paddingTop={{ md: 'xl', lg: 'xxxl' }}
         >
-          <Styled.Title mb="xxs">{props?.feature?.heroCard?.title}</Styled.Title>
+          <Styled.Title>{props?.feature?.heroCard?.title}</Styled.Title>
           <Styled.Summary color="text.secondary">
+            {props?.feature?.heroCard?.summary} {props?.feature?.heroCard?.summary}{' '}
+            {props?.feature?.heroCard?.summary} {props?.feature?.heroCard?.summary}{' '}
             {props?.feature?.heroCard?.summary}
           </Styled.Summary>
         </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -108,8 +108,6 @@ function HeroListFeature(props = {}) {
         >
           <Styled.Title>{props?.feature?.heroCard?.title}</Styled.Title>
           <Styled.Summary color="text.secondary">
-            {props?.feature?.heroCard?.summary} {props?.feature?.heroCard?.summary}{' '}
-            {props?.feature?.heroCard?.summary} {props?.feature?.heroCard?.summary}{' '}
             {props?.feature?.heroCard?.summary}
           </Styled.Summary>
         </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.styles.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.styles.js
@@ -17,17 +17,28 @@ const twoCardlayout = ({ length }) => {
 
 const Title = withTheme(styled.div`
   ${TypeStyles.H3}
+  margin-bottom: ${themeGet('space.xxs')};
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+
+  @media screen and (min-width: ${themeGet('breakpoints.md')}) {
+    ${TypeStyles.H3}
+    margin-bottom: ${themeGet('space.xxs')};
+  }
+  @media screen and (min-width: ${themeGet('breakpoints.lg')}) {
+    ${TypeStyles.H2}
+    margin-bottom: ${themeGet('space.xxs')};
+  }
+
   ${system}
 `);
 
 const Summary = withTheme(styled.div`
   ${TypeStyles.SmallBodyText}
   display: -webkit-box;
-  -webkit-line-clamp: 8;
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
   ${system}

--- a/packages/web-shared/ui-kit/Typography/_typeStyles.js
+++ b/packages/web-shared/ui-kit/Typography/_typeStyles.js
@@ -37,7 +37,7 @@ const H3 = () => css`
   ${shared}
 
   font-size: ${utils.rem('24px')};
-  line-height: ${utils.rem('28px')};
+  line-height: ${utils.rem('30px')};
   font-weight: 700;
 `;
 


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6811682830

Match the hero card style to designs.

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

Improved responsiveness and typography for titles and summaries.

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Check out a hero feature on any screen size. It should look pleasing to the eye.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="1220" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/eba27d12-dc71-4ad0-8374-ec65a7c86c90">| <img width="1226" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/7924a872-e152-43a2-a594-1184805d1df6"> |
|<img width="781" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/84157741-314c-4e63-9179-47fcb516819f">|<img width="791" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/9310c3d8-bb53-4601-82fa-25744711007f"> |
| <img width="671" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/ba33860f-f3b7-4276-b1be-abde7ad6ff8a">|<img width="580" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/de82189f-8019-4589-ab32-84b4f535aa10">|

