### PR TITLE
fix: content single item on mobile doesnt fill the full height on mobile

### DIFF
--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -39,6 +39,11 @@ const Modal = (props = {}) => {
     dispatchBreadcrumb(resetBreadcrumb());
   }
 
+  useEffect(() => {
+    const body = document.querySelector('body');
+    body.style.overflow = state.isOpen ? 'hidden' : 'auto';
+  }, [state.isOpen])
+
   return (
     <Box>
       <Styled.Modal show={state.isOpen}>


### PR DESCRIPTION
## 🐛 Issue

issue - https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6801492005


## ✏️ Solution

fix scroll issue in mobile view 

## 🔬 To Test

1. Open web page in mobile browser 
2. Select one content item and scroll up and down 

## 📸 Screenshots

https://github.com/ApollosProject/apollos-embeds/assets/28708210/d2b696d5-43a2-481a-89fe-211b71e4952d


