### PR TITLE
fix: add church logo above search bar

### DIFF
--- a/packages/web-shared/components/Logo/Logo.js
+++ b/packages/web-shared/components/Logo/Logo.js
@@ -6,7 +6,14 @@ import Styled from './Logo.styles';
 
 import { Box, systemPropTypes } from '../../ui-kit';
 
-function Logo({ fill, size, theme, source, ...rest }) {
+function Logo({ fill, size, padding, theme, source, ...rest }) {
+  let themeData = '';
+  try {
+    themeData = JSON.parse(theme);
+  } catch (error) {
+    console.error('Error parsing JSON');
+  }
+
   return (
     <Box {...rest}>
       <Styled.Image
@@ -14,6 +21,8 @@ function Logo({ fill, size, theme, source, ...rest }) {
         alt="Logo"
         size={size}
         fill={fill}
+        padding={padding}
+        backgroundColor={themeData?.colors?.primary ?? ''}
       />
     </Box>
   );

--- a/packages/web-shared/components/Logo/Logo.js
+++ b/packages/web-shared/components/Logo/Logo.js
@@ -15,15 +15,8 @@ function Logo({ fill, size, padding, theme, source, ...rest }) {
   }
 
   return (
-    <Box {...rest}>
-      <Styled.Image
-        src={source || './icon.png'}
-        alt="Logo"
-        size={size}
-        fill={fill}
-        padding={padding}
-        backgroundColor={themeData?.colors?.primary ?? ''}
-      />
+    <Box backgroundColor={themeData?.colors?.primary ?? ''} {...rest}>
+      <Styled.Image src={source || './icon.png'} alt="Logo" size={size} fill={fill} />
     </Box>
   );
 }

--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { useCurrentChurch } from '../../hooks';
 import { systemPropTypes } from '../../ui-kit/_lib/system';
 import Styled from './Modal.styles';
 import { Box } from '../../ui-kit';
@@ -16,6 +17,12 @@ import {
   useBreadcrumbDispatch,
 } from '../../providers/BreadcrumbProvider';
 import { X } from 'phosphor-react';
+import Logo from '../Logo';
+
+function ChurchLogo(props) {
+  const { currentChurch } = useCurrentChurch();
+  return <Logo source={currentChurch?.logo} theme={currentChurch?.theme} padding={10} {...props} />;
+}
 
 const Modal = (props = {}) => {
   const [state, dispatch] = useModal();
@@ -42,7 +49,7 @@ const Modal = (props = {}) => {
   useEffect(() => {
     const body = document.querySelector('body');
     body.style.overflow = state.isOpen ? 'hidden' : 'auto';
-  }, [state.isOpen])
+  }, [state.isOpen]);
 
   return (
     <Box>
@@ -50,6 +57,34 @@ const Modal = (props = {}) => {
         {state.content ? (
           <>
             <Styled.ModalContainer>
+              <Box
+                width="100%"
+                display="flex"
+                mb="s"
+                alignItems="flex-start"
+                justifyContent="space-between"
+                flexDirection={{ _: 'column-reverse', sm: 'row' }}
+              >
+                <Box width={{ _: '0', sm: '10%' }}></Box>
+                <ChurchLogo
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  margin="40px"
+                />
+                <Box
+                  width={{ _: '100%', sm: '10%' }}
+                  mb={{ _: 'xs', sm: '0' }}
+                  ml={{ _: '0', sm: 'xs' }}
+                  display="flex"
+                  justifyContent="flex-end"
+                  alignItems="center"
+                >
+                  <Styled.Icon onClick={handleCloseModal} ml={{ _: 'auto', sm: '0' }}>
+                    <X size={16} weight="bold" />
+                  </Styled.Icon>
+                </Box>
+              </Box>
               <Box
                 width="100%"
                 display="flex"
@@ -71,21 +106,7 @@ const Modal = (props = {}) => {
                 >
                   <Searchbar width="100%" />
                 </Box>
-                <Box
-                  width={{ _: '100%', sm: '10%' }}
-                  mb={{ _: 'xs', sm: '0' }}
-                  ml={{ _: '0', sm: 'xs' }}
-                  display="flex"
-                  justifyContent="flex-end"
-                  alignItems="center"
-                >
-                  <Styled.Icon
-                    onClick={handleCloseModal}
-                    ml={{ _: 'auto', sm: '0' }}
-                  >
-                    <X size={16} weight="bold" />
-                  </Styled.Icon>
-                </Box>
+                <Box width={{ _: '0', sm: '10%' }}></Box>
               </Box>
               <Breadcrumbs />
               <Box

--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -68,9 +68,12 @@ const Modal = (props = {}) => {
                 <Box width={{ _: '0', sm: '10%' }}></Box>
                 <ChurchLogo
                   display="flex"
-                  alignItems="center"
+                  alignSelf="center"
                   justifyContent="center"
-                  margin="40px"
+                  margin="20px"
+                  p="s"
+                  size="60px"
+                  borderRadius="xl"
                 />
                 <Box
                   width={{ _: '100%', sm: '10%' }}


### PR DESCRIPTION
## 🐛 Issue

issue - https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6816432407

## ✏️ Solution

Add church logo above search bar 

## 🔬 To Test

1. Web embeds home page -> select a content item
http://localhost:3000/?id=internship-TWVkaWFDb250ZW50SXRlbS0zZjFiN2RhOC0yNzJiLTRiMmEtYTZhMy00ZWJjMzVlOTRkNjg%3D

## 📸 Screenshots

<img width="1673" alt="Screenshot 2023-12-13 at 3 53 18 PM" src="https://github.com/ApollosProject/apollos-embeds/assets/28708210/12c72f5e-20a9-42ee-8112-f7cbfda0878f">

