### PR TITLE
(Web-Embeds) Remove unsupported types for all routing switches

### DIFF
--- a/packages/web-shared/components/InformationalContentSingle.js
+++ b/packages/web-shared/components/InformationalContentSingle.js
@@ -13,6 +13,7 @@ import { useHTMLContent, useVideoMediaProgress } from '../hooks';
 import VideoPlayer from './VideoPlayer';
 import InteractWhenLoaded from './InteractWhenLoaded';
 
+// InformationalContentItem has been removed since it is unsupported. This file is unused
 function InformationalContentSingle(props = {}) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -70,7 +71,7 @@ function InformationalContentSingle(props = {}) {
   const hasChildContent = childContentItems?.length > 0;
   const hasSiblingContent = siblingContentItems?.length > 0;
   const validFeatures = featureFeed?.features?.filter(
-    feature => !!FeatureFeedComponentMap[feature?.__typename],
+    (feature) => !!FeatureFeedComponentMap[feature?.__typename]
   );
   const hasFeatures = validFeatures?.length;
 
@@ -81,13 +82,13 @@ function InformationalContentSingle(props = {}) {
     </BodyText>
   );
 
-  const handleActionPress = item => {
+  const handleActionPress = (item) => {
     if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item)}`,
           title: item.title,
-        }),
+        })
       );
       setSearchParams(`?id=${getURLFromType(item)}`);
     }

--- a/packages/web-shared/utils/getContentFromURL.js
+++ b/packages/web-shared/utils/getContentFromURL.js
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  ContentItemProvider,
-  FeatureFeedProvider,
-  ContentFeedProvider,
-} from '../providers';
+import { ContentItemProvider, FeatureFeedProvider, ContentFeedProvider } from '../providers';
 import {
   ContentSingle,
   ContentSeriesSingle,
@@ -19,7 +15,7 @@ function getContentFromURL(url) {
   const { type, randomId } = parseSlugToIdAndType(url);
 
   switch (type) {
-    case 'EventContentItem':
+    // case 'EventContentItem':
     case 'MediaContentItem':
     case 'WeekendContentItem':
     case 'UniversalContentItem': {
@@ -27,50 +23,27 @@ function getContentFromURL(url) {
         variables: { id: `${type}:${randomId}` },
       };
 
-      return (
-        <ContentItemProvider Component={ContentSingle} options={options} />
-      );
+      return <ContentItemProvider Component={ContentSingle} options={options} />;
     }
     case 'ContentSeriesContentItem': {
       const options = {
         variables: { id: `${type}:${randomId}` },
       };
 
-      return (
-        <ContentItemProvider
-          Component={ContentSeriesSingle}
-          options={options}
-        />
-      );
-    }
-    case 'InformationalContentItem': {
-      const options = {
-        variables: { id: `${type}:${randomId}` },
-      };
-
-      return (
-        <ContentItemProvider
-          Component={InformationalContentSingle}
-          options={options}
-        />
-      );
+      return <ContentItemProvider Component={ContentSeriesSingle} options={options} />;
     }
     case 'Livestream': {
       const options = {
         variables: { id: `${type}:${randomId}` },
       };
 
-      return (
-        <ContentItemProvider Component={LivestreamSingle} options={options} />
-      );
+      return <ContentItemProvider Component={LivestreamSingle} options={options} />;
     }
     case 'ContentChannel': {
       const options = {
         variables: { id: `${type}:${randomId}` },
       };
-      return (
-        <ContentFeedProvider Component={ContentChannel} options={options} />
-      );
+      return <ContentFeedProvider Component={ContentChannel} options={options} />;
     }
     case 'Url': {
       return <h1>External Url</h1>;
@@ -79,9 +52,7 @@ function getContentFromURL(url) {
       const options = {
         variables: { itemId: `${type}:${randomId}` },
       };
-      return (
-        <FeatureFeedProvider Component={FeatureFeedList} options={options} />
-      );
+      return <FeatureFeedProvider Component={FeatureFeedList} options={options} />;
     }
     default: {
       return <Box>No Content</Box>;

--- a/packages/web-shared/utils/getPathFromType.js
+++ b/packages/web-shared/utils/getPathFromType.js
@@ -6,8 +6,6 @@ function getPathFromType(node) {
   const [type, randomId] = node?.id?.split(':');
 
   switch (type) {
-    case 'EventContentItem':
-    case 'InformationalContentItem':
     case 'MediaContentItem':
     case 'WeekendContentItem':
     case 'UniversalContentItem':
@@ -27,9 +25,7 @@ function getPathFromType(node) {
       return node.url;
     }
     default: {
-      console.warn(
-        `Routing for node type ${type} not set up. Please add it to getPathFromType.js`
-      );
+      console.warn(`Routing for node type ${type} not set up. Please add it to getPathFromType.js`);
       return '/';
     }
   }

--- a/packages/web-shared/utils/getURLFromType.js
+++ b/packages/web-shared/utils/getURLFromType.js
@@ -8,8 +8,6 @@ function getURLFromType(node) {
   const [type, randomId] = node?.id?.split(':');
 
   switch (type) {
-    case 'EventContentItem':
-    case 'InformationalContentItem':
     case 'MediaContentItem':
     case 'WeekendContentItem':
     case 'UniversalContentItem':
@@ -28,9 +26,7 @@ function getURLFromType(node) {
       return node.url;
     }
     default: {
-      console.warn(
-        `Routing for node type ${type} not set up. Please add it to getURLFromType.js`
-      );
+      console.warn(`Routing for node type ${type} not set up. Please add it to getURLFromType.js`);
       return '/';
     }
   }


### PR DESCRIPTION
## 🐛 Issue

[(Web-Embeds) Remove unsupported types for all routing switches](https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6830930260/edit?focus=kanban_card_title)

There are unsupported content item types that determine routing that need to be removed

## ✏️ Solution

Remove all  unsupported content item types

## 🔬 To Test

1. Check route switching content item files like `getURLFromType`
2. It should only have these content item types: MediaContentItem, WeekendContentItem, UniversalContentItem, ContentSeriesContentItem
3. Run embeds and make sure everything is working the same
4. Unsupported types will probably no longer work

