### PR TITLE
(Web) Increase Vertical Padding Between Cards Sections

### DIFF
--- a/packages/web-shared/components/ContentChannel.js
+++ b/packages/web-shared/components/ContentChannel.js
@@ -28,14 +28,8 @@ function ContentChannel(props = {}) {
   };
 
   return (
-    <Box
-      pb="l"
-      display="flex"
-      flexDirection="column"
-      alignItems="center"
-      {...props}
-    >
-      <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gridGap="20px">
+    <Box pb="l" display="flex" flexDirection="column" alignItems="center" {...props}>
+      <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gridGap="70px 20px">
         {props.data?.edges?.map((item, index) => {
           return (
             <ContentCard
@@ -50,12 +44,7 @@ function ContentChannel(props = {}) {
         })}
       </Box>
       {hasMorePages ? (
-        <Button
-          mt="l"
-          justifySelf="center"
-          title="Load More"
-          onClick={handleLoadMore}
-        />
+        <Button mt="l" justifySelf="center" title="Load More" onClick={handleLoadMore} />
       ) : null}
     </Box>
   );

--- a/packages/web-shared/components/ContentSeriesSingle.js
+++ b/packages/web-shared/components/ContentSeriesSingle.js
@@ -201,7 +201,7 @@ function ContentSeriesSingle(props = {}) {
               <H3 mb="xs">{props.feature?.title}</H3>
               <Box
                 display="grid"
-                gridGap="30px"
+                gridGap="100px 30px"
                 gridTemplateColumns={{
                   _: 'repeat(1, minmax(0, 1fr));',
                   md: 'repeat(2, minmax(0, 1fr));',

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -81,10 +81,14 @@ function ContentSingle(props = {}) {
   );
   const hasFeatures = validFeatures?.length;
   const formattedStartDate = props?.data?.start
-      ? format(parseISO(props.data.start), 'eee, MMMM do, yyyy')
-      : null;
-  const formattedStartToEnd = props?.data?.start && props?.data?.end
-      ? `${format(parseISO(props.data.start), 'hh:mm a')} — ${format(parseISO(props.data.end), 'hh:mm a')}`
+    ? format(parseISO(props.data.start), 'eee, MMMM do, yyyy')
+    : null;
+  const formattedStartToEnd =
+    props?.data?.start && props?.data?.end
+      ? `${format(parseISO(props.data.start), 'hh:mm a')} — ${format(
+          parseISO(props.data.end),
+          'hh:mm a'
+        )}`
       : null;
   const handleActionPress = (item) => {
     if (searchParams.get('id') !== getURLFromType(item)) {
@@ -102,9 +106,9 @@ function ContentSingle(props = {}) {
     }
   };
   const infoDivider = (
-      <BodyText color="text.tertiary" mx="xs">
-        |
-      </BodyText>
+    <BodyText color="text.tertiary" mx="xs">
+      |
+    </BodyText>
   );
 
   return (
@@ -180,17 +184,13 @@ function ContentSingle(props = {}) {
                     {parentChannel?.name || props?.data?.location}
                   </BodyText>
                 ) : null}
-                {formattedStartDate  ? infoDivider : null}
+                {formattedStartDate ? infoDivider : null}
                 {formattedStartDate ? (
-                    <BodyText color="text.secondary">
-                      {formattedStartDate}
-                    </BodyText>
+                  <BodyText color="text.secondary">{formattedStartDate}</BodyText>
                 ) : null}
-                {formattedStartToEnd  ? infoDivider : null}
+                {formattedStartToEnd ? infoDivider : null}
                 {formattedStartToEnd ? (
-                    <BodyText color="text.secondary">
-                      {formattedStartToEnd}
-                    </BodyText>
+                  <BodyText color="text.secondary">{formattedStartToEnd}</BodyText>
                 ) : null}
               </Box>
             </Box>
@@ -220,7 +220,7 @@ function ContentSingle(props = {}) {
 
             <Box
               display="grid"
-              gridGap="30px"
+              gridGap="100px 30px"
               gridTemplateColumns={{
                 _: 'repeat(1, minmax(0, 1fr));',
                 md: 'repeat(2, minmax(0, 1fr));',
@@ -254,7 +254,7 @@ function ContentSingle(props = {}) {
               <H3 mb="xs">{props.feature?.title}</H3>
               <Box
                 display="grid"
-                gridGap="30px"
+                gridGap="100px 30px"
                 gridTemplateColumns={{
                   _: 'repeat(1, minmax(0, 1fr));',
                   md: 'repeat(2, minmax(0, 1fr));',

--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.styles.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.styles.js
@@ -48,7 +48,7 @@ const Container = styled.div`
   display: grid;
 
   grid-template-rows: auto;
-  grid-gap: 20px;
+  grid-gap: 70px 20px;
 
   grid-template-columns: repeat(1, 1fr);
 

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -3,23 +3,9 @@ import get from 'lodash/get';
 import { useSearchParams } from 'react-router-dom';
 
 import { getURLFromType } from '../../../utils';
-import {
-  ContentCard,
-  Box,
-  H3,
-  systemPropTypes,
-  Button,
-  ButtonGroup,
-} from '../../../ui-kit';
-import {
-  add as addBreadcrumb,
-  useBreadcrumbDispatch,
-} from '../../../providers/BreadcrumbProvider';
-import {
-  open as openModal,
-  set as setModal,
-  useModal,
-} from '../../../providers/ModalProvider';
+import { ContentCard, Box, H3, systemPropTypes, Button, ButtonGroup } from '../../../ui-kit';
+import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../../providers/BreadcrumbProvider';
+import { open as openModal, set as setModal, useModal } from '../../../providers/ModalProvider';
 import { CaretRight } from 'phosphor-react';
 
 import Carousel from 'react-multi-carousel';
@@ -45,7 +31,7 @@ function HorizontalCardListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (item.action === 'OPEN_URL'){
+    if (item.action === 'OPEN_URL') {
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 
@@ -66,22 +52,15 @@ function HorizontalCardListFeature(props = {}) {
   };
 
   const handlePrimaryActionPress = () => {
-    if (
-      searchParams.get('id') !==
-      getURLFromType(props?.feature?.primaryAction.relatedNode)
-    ) {
+    if (searchParams.get('id') !== getURLFromType(props?.feature?.primaryAction.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
-          url: `?id=${getURLFromType(
-            props?.feature?.primaryAction.relatedNode
-          )}`,
+          url: `?id=${getURLFromType(props?.feature?.primaryAction.relatedNode)}`,
           title: props?.feature?.title,
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      state.modal
-        ? setSearchParams({ id })
-        : setSearchParams({ id, action: 'viewall' });
+      state.modal ? setSearchParams({ id }) : setSearchParams({ id, action: 'viewall' });
     }
   };
 
@@ -90,7 +69,7 @@ function HorizontalCardListFeature(props = {}) {
   }
 
   return (
-    <Box pb="xxl" {...props}>
+    <Box pb="xxl" mb="l" {...props}>
       <Box display="flex" alignItems="center" mb="xs">
         <H3 flex="1" mr="xs">
           {props.feature.title || props.feature.subtitle}
@@ -129,14 +108,7 @@ function HorizontalCardListFeature(props = {}) {
           ))}
         </Carousel>
       ) : (
-        <Box
-          width="100%"
-          display="flex"
-          justifyContent="center"
-          pt="l"
-          px="l"
-          textAlign="center"
-        >
+        <Box width="100%" display="flex" justifyContent="center" pt="l" px="l" textAlign="center">
           {props.feature.title === 'Continue Watching' ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
@@ -3,23 +3,9 @@ import get from 'lodash/get';
 import { useSearchParams } from 'react-router-dom';
 
 import { getURLFromType } from '../../../utils';
-import {
-  Box,
-  H3,
-  systemPropTypes,
-  Button,
-  MediaItem,
-  ButtonGroup,
-} from '../../../ui-kit';
-import {
-  add as addBreadcrumb,
-  useBreadcrumbDispatch,
-} from '../../../providers/BreadcrumbProvider';
-import {
-  open as openModal,
-  set as setModal,
-  useModal,
-} from '../../../providers/ModalProvider';
+import { Box, H3, systemPropTypes, Button, MediaItem, ButtonGroup } from '../../../ui-kit';
+import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../../providers/BreadcrumbProvider';
+import { open as openModal, set as setModal, useModal } from '../../../providers/ModalProvider';
 
 import Carousel from 'react-multi-carousel';
 import { CaretRight } from 'phosphor-react';
@@ -46,7 +32,7 @@ function HorizontalMediaListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (item.action === 'OPEN_URL'){
+    if (item.action === 'OPEN_URL') {
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 
@@ -67,22 +53,15 @@ function HorizontalMediaListFeature(props = {}) {
   };
 
   const handlePrimaryActionPress = () => {
-    if (
-      searchParams.get('id') !==
-      getURLFromType(props?.feature?.primaryAction.relatedNode)
-    ) {
+    if (searchParams.get('id') !== getURLFromType(props?.feature?.primaryAction.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
-          url: `?id=${getURLFromType(
-            props?.feature?.primaryAction.relatedNode
-          )}`,
+          url: `?id=${getURLFromType(props?.feature?.primaryAction.relatedNode)}`,
           title: props?.feature?.title,
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      state.modal
-        ? setSearchParams({ id })
-        : setSearchParams({ id, action: 'viewall' });
+      state.modal ? setSearchParams({ id }) : setSearchParams({ id, action: 'viewall' });
     }
   };
 
@@ -91,13 +70,12 @@ function HorizontalMediaListFeature(props = {}) {
   }
 
   return (
-    <Box pb="xl" {...props}>
+    <Box pb="xl" mb="l" {...props}>
       <Box display="flex" alignItems="center" mb="xs">
         <H3 flex="1" mr="xs">
           {props.feature.title || props.feature.subtitle}
         </H3>
-        {props?.feature?.items?.length >= SHOW_VIEW_ALL_LIMIT &&
-        props?.feature?.primaryAction ? (
+        {props?.feature?.items?.length >= SHOW_VIEW_ALL_LIMIT && props?.feature?.primaryAction ? (
           <Button
             title="View All"
             variant="link"
@@ -136,14 +114,7 @@ function HorizontalMediaListFeature(props = {}) {
           </Carousel>
         </Box>
       ) : (
-        <Box
-          width="100%"
-          display="flex"
-          justifyContent="center"
-          pt="l"
-          px="l"
-          textAlign="center"
-        >
+        <Box width="100%" display="flex" justifyContent="center" pt="l" px="l" textAlign="center">
           {props.feature.title === 'Continue Watching' ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!

--- a/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.styles.js
+++ b/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.styles.js
@@ -18,7 +18,7 @@ const Container = styled.div`
   grid-template-rows: auto;
   grid-auto-rows: 1fr;
   grid-auto-columns: 1fr;
-  grid-gap: 20px;
+  grid-gap: 70px 20px;
   ${twoCardlayout}
 
   @media screen and (max-width: ${themeGet('breakpoints.lg')}) {

--- a/packages/web-shared/components/FeatureFeedList/FeatureFeedListGrid.js
+++ b/packages/web-shared/components/FeatureFeedList/FeatureFeedListGrid.js
@@ -5,16 +5,9 @@ import { withTheme } from 'styled-components';
 
 import { getURLFromType } from '../../utils';
 import { Box, ContentCard, H3 } from '../../ui-kit';
-import {
-  add as addBreadcrumb,
-  useBreadcrumbDispatch,
-} from '../../providers/BreadcrumbProvider';
+import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../providers/BreadcrumbProvider';
 
-import {
-  open as openModal,
-  set as setModal,
-  useModal,
-} from '../../providers/ModalProvider';
+import { open as openModal, set as setModal, useModal } from '../../providers/ModalProvider';
 
 function FeatureFeedListGrid(props = {}) {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -42,7 +35,7 @@ function FeatureFeedListGrid(props = {}) {
     <Box pb="l">
       <Box
         display="grid"
-        gridGap="20px"
+        gridGap="70px 20px"
         gridTemplateColumns={{
           _: 'repeat(1, 1fr)',
           md: 'repeat(2, 1fr)',

--- a/packages/web-shared/components/InformationalContentSingle.js
+++ b/packages/web-shared/components/InformationalContentSingle.js
@@ -70,7 +70,7 @@ function InformationalContentSingle(props = {}) {
   const hasChildContent = childContentItems?.length > 0;
   const hasSiblingContent = siblingContentItems?.length > 0;
   const validFeatures = featureFeed?.features?.filter(
-    feature => !!FeatureFeedComponentMap[feature?.__typename],
+    (feature) => !!FeatureFeedComponentMap[feature?.__typename]
   );
   const hasFeatures = validFeatures?.length;
 
@@ -81,13 +81,13 @@ function InformationalContentSingle(props = {}) {
     </BodyText>
   );
 
-  const handleActionPress = item => {
+  const handleActionPress = (item) => {
     if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item)}`,
           title: item.title,
-        }),
+        })
       );
       setSearchParams(`?id=${getURLFromType(item)}`);
     }
@@ -175,7 +175,7 @@ function InformationalContentSingle(props = {}) {
 
             <Box
               display="grid"
-              gridGap="30px"
+              gridGap="100px 30px"
               gridTemplateColumns={{
                 _: 'repeat(1, minmax(0, 1fr));',
                 md: 'repeat(2, minmax(0, 1fr));',
@@ -205,7 +205,7 @@ function InformationalContentSingle(props = {}) {
             <H3 mb="xs">{props.feature?.title}</H3>
             <Box
               display="grid"
-              gridGap="30px"
+              gridGap="100px 30px"
               gridTemplateColumns={{
                 _: 'repeat(1, minmax(0, 1fr));',
                 md: 'repeat(2, minmax(0, 1fr));',

--- a/packages/web-shared/components/LivestreamSingle.js
+++ b/packages/web-shared/components/LivestreamSingle.js
@@ -164,7 +164,7 @@ function LivestreamSingle(props = {}) {
         {hasChildContent ? (
           <Box mb="l">
             <H3 mb="xs">{props.feature.title || props.feature.subtitle}</H3>
-            <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gridGap="20px">
+            <Box display="grid" gridTemplateColumns="repeat(3, 1fr)" gridGap="70px 20px">
               {childContentItems?.map((item, index) => (
                 <MediaItem
                   key={item.node?.title}


### PR DESCRIPTION
## 🐛 Issue

[(Web) Increase Vertical Padding Between Cards Sections](https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6797583038)

## ✏️ Solution

Add more vertical padding (3-3.5x the length of the horizontal padding) to all components that use `display: grid` to render a collection of cards

## 🔬 To Test

1. Navigate to any feed with View all, or any content item using a grid
2. Grid should have more vertical space between rows

## 📸 Screenshots
Before: 

<img width="1329" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/3ceba714-85fb-4d39-a1b1-416516385d17">

After:

https://github.com/ApollosProject/apollos-embeds/assets/68402088/0687fa4e-42b8-4248-be02-ab661f783240



