### PR TITLE
(Web)(Liquid) Remove Top Featured Card on Blog Page

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -16,7 +16,7 @@ function HeroListFeature(props = {}) {
   const navigate = useNavigate();
 
   const handleActionPress = (item) => {
-    if (item.action === 'OPEN_URL'){
+    if (item.action === 'OPEN_URL') {
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -3,23 +3,9 @@ import get from 'lodash/get';
 import { useSearchParams } from 'react-router-dom';
 
 import { getURLFromType } from '../../../utils';
-import {
-  ContentCard,
-  Box,
-  H3,
-  systemPropTypes,
-  Button,
-  ButtonGroup,
-} from '../../../ui-kit';
-import {
-  add as addBreadcrumb,
-  useBreadcrumbDispatch,
-} from '../../../providers/BreadcrumbProvider';
-import {
-  open as openModal,
-  set as setModal,
-  useModal,
-} from '../../../providers/ModalProvider';
+import { ContentCard, Box, H3, systemPropTypes, Button, ButtonGroup } from '../../../ui-kit';
+import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../../providers/BreadcrumbProvider';
+import { open as openModal, set as setModal, useModal } from '../../../providers/ModalProvider';
 import { CaretRight } from 'phosphor-react';
 
 import Carousel from 'react-multi-carousel';
@@ -45,7 +31,7 @@ function HorizontalCardListFeature(props = {}) {
   const [state, dispatch] = useModal();
 
   const handleActionPress = (item) => {
-    if (item.action === 'OPEN_URL'){
+    if (item.action === 'OPEN_URL') {
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 
@@ -66,22 +52,15 @@ function HorizontalCardListFeature(props = {}) {
   };
 
   const handlePrimaryActionPress = () => {
-    if (
-      searchParams.get('id') !==
-      getURLFromType(props?.feature?.primaryAction.relatedNode)
-    ) {
+    if (searchParams.get('id') !== getURLFromType(props?.feature?.primaryAction.relatedNode)) {
       dispatchBreadcrumb(
         addBreadcrumb({
-          url: `?id=${getURLFromType(
-            props?.feature?.primaryAction.relatedNode
-          )}`,
+          url: `?id=${getURLFromType(props?.feature?.primaryAction.relatedNode)}`,
           title: props?.feature?.title,
         })
       );
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
-      state.modal
-        ? setSearchParams({ id })
-        : setSearchParams({ id, action: 'viewall' });
+      state.modal ? setSearchParams({ id }) : setSearchParams({ id, action: 'viewall' });
     }
   };
 
@@ -104,8 +83,47 @@ function HorizontalCardListFeature(props = {}) {
           />
         ) : null}
       </Box>
-
-      {props?.feature?.cards?.length >= 1 ? (
+      {props?.feature?.primaryAction && props?.feature?.cards?.length <= 2 ? (
+        <Box
+          display="flex"
+          justifyContent="center"
+          flexDirection="column"
+          mt="xs"
+          mb={{ _: '0', md: 'l' }}
+        >
+          {props?.feature?.cards?.length === 1 ? (
+            <ContentCard
+              key={props?.feature?.cards[0].title}
+              image={props?.feature?.cards[0].coverImage}
+              title={props?.feature?.cards[0].title}
+              summary={props?.feature?.cards[0].subtitle}
+              videoMedia={get(props?.feature?.cards[0], 'relatedNode?.videos[0]', null)}
+              onClick={() => handleActionPress(props?.feature?.cards[0])}
+              horizontal={true}
+            />
+          ) : (
+            <Box
+              display="grid"
+              gridGap="20px"
+              gridTemplateColumns={{
+                _: 'repeat(1, 1fr)',
+                md: 'repeat(2, 1fr)',
+              }}
+            >
+              {props?.feature?.cards?.map((item) => (
+                <ContentCard
+                  key={item.title}
+                  image={item.coverImage}
+                  title={item.title}
+                  summary={item.summary}
+                  onClick={() => handleActionPress(item)}
+                  videoMedia={get(item, 'relatedNode?.videos[0]', null)}
+                />
+              ))}
+            </Box>
+          )}
+        </Box>
+      ) : props?.feature?.cards?.length >= 1 ? (
         <Carousel
           arrows={false}
           swipeable={true}
@@ -129,14 +147,7 @@ function HorizontalCardListFeature(props = {}) {
           ))}
         </Carousel>
       ) : (
-        <Box
-          width="100%"
-          display="flex"
-          justifyContent="center"
-          pt="l"
-          px="l"
-          textAlign="center"
-        >
+        <Box width="100%" display="flex" justifyContent="center" pt="l" px="l" textAlign="center">
           {props.feature.title === 'Continue Watching' ? (
             <Box fontSize="16px" fontWeight="600" color="base.primary">
               All caught up? Check out our other sections for more content!

--- a/packages/web-shared/ui-kit/ContentCard/ContentCard.js
+++ b/packages/web-shared/ui-kit/ContentCard/ContentCard.js
@@ -2,29 +2,16 @@ import React from 'react';
 import { withTheme } from 'styled-components';
 import { Check } from 'phosphor-react';
 
-import {
-  SmallBodyText,
-  Box,
-  H4,
-  systemPropTypes,
-  ProgressBar,
-} from '../../ui-kit';
+import { SmallBodyText, Box, H4, systemPropTypes, ProgressBar } from '../../ui-kit';
 import { useVideoMediaProgress } from '../../hooks';
 import { getPercentWatched } from '../../utils';
-import {
-  BottomSlot,
-  CompleteIndicator,
-  Title,
-  Summary,
-} from './ContentCard.styles';
+import { BottomSlot, CompleteIndicator, Title, Summary } from './ContentCard.styles';
 
 function ContentCard(props = {}) {
-  const { userProgress, loading: videoProgressLoading } = useVideoMediaProgress(
-    {
-      variables: { id: props.videoMedia?.id },
-      skip: !props.videoMedia?.id,
-    }
-  );
+  const { userProgress, loading: videoProgressLoading } = useVideoMediaProgress({
+    variables: { id: props.videoMedia?.id },
+    skip: !props.videoMedia?.id,
+  });
 
   const percentWatched = getPercentWatched({
     duration: props.videoMedia?.duration,
@@ -48,6 +35,7 @@ function ContentCard(props = {}) {
           backgroundSize="cover"
           paddingBottom="56.25%"
           backgroundPosition="center"
+          backgroundRepeat="no-repeat"
           backgroundColor="material.regular"
           backgroundImage={`url(${
             props.image?.sources[0].uri ? props.image.sources[0].uri : null
@@ -66,11 +54,7 @@ function ContentCard(props = {}) {
         </BottomSlot>
       </Box>
       {/* Masthead */}
-      <Box
-        padding="base"
-        backdropFilter="blur(64px)"
-        width={props.horizontal ? '50%' : ''}
-      >
+      <Box padding="base" backdropFilter="blur(64px)" width={props.horizontal ? '50%' : ''}>
         <SmallBodyText color="text.secondary">{props.subtitle}</SmallBodyText>
         <Title>{props.title}</Title>
         <Summary color="text.secondary">{props.summary} </Summary>


### PR DESCRIPTION
## 🐛 Issue

[(Web)(Liquid) Remove Top Featured Card on Blog Page](https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6902381512)

Liquid wants the hero card feature but without the top feature card

## ✏️ Solution

Convert `HorizontalCardListFeature` to satisfy this need. When `HorizontalCardListFeature` is given a `primaryAction` and has 2 cards or less, then it will be formatted similar to how it is down on the `HeroCardFeature`.

If no `primaryAction`, or has 3+ cards, it will render as normal with a `Carousel` 

## 🔬 To Test

1. Navigate to a feed with `HorizontalCardListFeature` with `primaryAction`
2. Might to adjust the code to use only 2 cards if there isn't a feature that meets the exact requirements
3. Should work as it normally does with the `HeroCardFeature`

## 📸 Screenshots

https://github.com/ApollosProject/apollos-embeds/assets/68402088/a862deb6-0d0a-4848-ba26-13dc93760c5c



### Liquid Chruch Example:

```
    <div
      data-type="FeatureFeed"
      data-church="liquid_church"
      data-feature-feed="FeatureFeed:7354b5f1-2aa4-4483-993f-4dcccae6e523"
      data-modal="true"
      class="apollos-widget"
    >
    </div>
```

<img width="1648" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/3a6f5d23-c342-4d82-9d7c-635a64ef9dc0">



### Cedar Creek Example:

```
     <div
      data-type="FeatureFeed"
      data-church="cedar_creek"
      data-feature-feed="FeatureFeed:669cbe0d-da62-40e7-a096-8c2194870081"
      data-modal="true"
      class="apollos-widget"
    >
    </div>
```

<img width="1645" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/68402088/2e6b335b-f34d-4869-9358-87a5d9d3fbc7">
