### PR TITLE
(Web) Single Page Embeds Cutting Off Bottom of Modal

### DIFF
--- a/packages/web-shared/components/Modal/Modal.styles.js
+++ b/packages/web-shared/components/Modal/Modal.styles.js
@@ -1,8 +1,8 @@
-import { withTheme } from "styled-components";
-import styled, { css, keyframes } from "styled-components";
-import { themeGet } from "@styled-system/theme-get";
+import { withTheme } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
+import { themeGet } from '@styled-system/theme-get';
 
-import { system } from "../../ui-kit/_lib/system";
+import { system } from '../../ui-kit/_lib/system';
 
 const slideIn = keyframes`
   from {
@@ -24,8 +24,8 @@ const slideOut = keyframes`
 `;
 
 const Modal = withTheme(styled.div`
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   position: fixed;
   bottom: 0;
   top: 0;
@@ -36,7 +36,7 @@ const Modal = withTheme(styled.div`
   align-items: center;
   z-index: 9999;
   animation: ${(props) => (props.show ? slideIn : slideOut)} 0.3s ease-in-out;
-  transform: translateY(${(props) => (props.show ? "0" : "100%")});
+  transform: translateY(${(props) => (props.show ? '0' : '100%')});
   ${system};
 `);
 
@@ -50,7 +50,7 @@ const ModalContainer = withTheme(styled.div`
   overflow-y: scroll;
   padding: 40px;
   box-sizing: border-box;
-  @media screen and (max-width: ${themeGet("breakpoints.sm")}) {
+  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
     padding: 16px;
   }
   ${system};
@@ -72,7 +72,7 @@ const Icon = withTheme(styled.div`
   width: 32px;
 
   &:hover {
-    color: ${themeGet("colors.base.secondary")};
+    color: ${themeGet('colors.base.secondary')};
     cursor: pointer;
   }
   ${system};


### PR DESCRIPTION
## 🐛 Issue

[(Web) Single Page Embeds Cutting Off Bottom of Modal](https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6865448645)

## ✏️ Solution
**_NOTE: Wasn't sure how to test, nor how to diagnose the problem.  Chrome, safari, and the phone's default browser all produced different bugs, although all related to the modal. The bug were also not consistently happening (mainly the bug where the page behind the modal is being scrolled)._** 

Based on testing the site and this [stackoverflow thread](https://stackoverflow.com/questions/37112218/css3-100vh-not-constant-in-mobile-browser), the issues seem to be caused by how browsers on mobile calculate view-width and view-height. By setting a fixed 100% height, it should (in theory) avoid trying to dynamically changing the height , and just take up the whole space.

## 🔬 To Test

**_N/A_**

## 📸 Screenshots

Default Browser (worst- major cut offs around the browser control area)

https://github.com/ApollosProject/apollos-embeds/assets/68402088/31658312-24bb-4743-8107-27a627544b61


Chrome (you can the the mobile just to adjust in real time as the browser control slides up and down)

https://github.com/ApollosProject/apollos-embeds/assets/68402088/3058e504-a99c-42be-8ffe-2967642dc453


Safari (were no issues in the video, but previous had the scrolling issue, but no modal cutoff)

https://github.com/ApollosProject/apollos-embeds/assets/68402088/bced8ccd-eedd-407e-a639-16af4b6ddc63

