### PR TITLE
fix: dont add a breadcrumb if a title isnt present.

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -53,12 +53,14 @@ function HorizontalCardListFeature(props = {}) {
 
   const handlePrimaryActionPress = () => {
     if (searchParams.get('id') !== getURLFromType(props?.feature?.primaryAction.relatedNode)) {
-      dispatchBreadcrumb(
-        addBreadcrumb({
-          url: `?id=${getURLFromType(props?.feature?.primaryAction.relatedNode)}`,
-          title: props?.feature?.title,
-        })
-      );
+      if (props?.feature?.title) {
+        dispatchBreadcrumb(
+          addBreadcrumb({
+            url: `?id=${getURLFromType(props?.feature?.primaryAction.relatedNode)}`,
+            title: props?.feature?.title,
+          })
+        );
+      }
       const id = getURLFromType(props?.feature?.primaryAction.relatedNode);
       state.modal ? setSearchParams({ id }) : setSearchParams({ id, action: 'viewall' });
     }


### PR DESCRIPTION
## 🐛 Issue

Issue - https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6856937764

## ✏️ Solution

not adding breadcrumb if empty title

## 🔬 To Test

2. http://localhost:3000/?id=html-feature-test-VW5pdmVyc2FsQ29udGVudEl0ZW0tMTU0MzczYzYtMDFkMy00NDM5LWE1YTUtMjY5NjcxYzIwYWJk

## 📸 Screenshots

<img width="1217" alt="Screenshot 2024-01-16 at 3 49 52 PM" src="https://github.com/ApollosProject/apollos-embeds/assets/28708210/f5c1a872-b618-4dc5-988d-e6dd4ce8b575">
