### PR TITLE
Fix: add ContentSeriesSingle to imports for feature embeds

### DIFF
--- a/packages/web-shared/embeds/FeatureFeed.js
+++ b/packages/web-shared/embeds/FeatureFeed.js
@@ -7,6 +7,7 @@ import {
   LivestreamSingle,
   Breadcrumbs,
   Modal,
+  ContentSeriesSingle,
 } from '../components';
 import { useModalState } from '../providers/ModalProvider';
 import { Box } from '../ui-kit';

--- a/packages/web-shared/embeds/Search.js
+++ b/packages/web-shared/embeds/Search.js
@@ -5,11 +5,12 @@ import { Searchbar } from '../components';
 
 import { ContentItemProvider, FeatureFeedProvider, ContentFeedProvider } from '../providers';
 import {
+  Breadcrumbs,
+  ContentChannel,
+  ContentSeriesSingle,
   ContentSingle,
   FeatureFeedList,
-  ContentChannel,
   LivestreamSingle,
-  Breadcrumbs,
   Modal,
 } from '../components';
 import { useModalState } from '../providers/ModalProvider';


### PR DESCRIPTION
## 🐛 Issue

https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6950727046

<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

## ✏️ Solution

Add import for series single to embeds.

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. http://bayside.localhost:3000/?id=romans-Q29udGVudFNlcmllc0NvbnRlbnRJdGVtLTNiN2U5Y2FkLTY1NWMtNDk2Ni04MjM4LTBkOTkzNTliM2NmNg%3D%3D
2. http://crossroads-tv.localhost:3000/?id=nehemiah-how-to-make-your-vision-a-reality-Q29udGVudFNlcmllc0NvbnRlbnRJdGVtLWFlNjNlY2Q4LTlkMzMtNGY1My1hNzAyLThmMWJhNDhkNmJmOQ%3D%3D

## 📸 Screenshots

<img width="1175" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/a453b646-3564-40b4-bdde-06dcfe6f8aab">
<img width="1157" alt="image" src="https://github.com/ApollosProject/apollos-embeds/assets/2528817/a12a7ca8-3d8a-4d37-9b69-2bd534242a03">

