### PR TITLE
Stop phospher from bombing on missing icon

### DIFF
--- a/packages/web-shared/ui-kit/PhospherIcon/PhospherIcon.js
+++ b/packages/web-shared/ui-kit/PhospherIcon/PhospherIcon.js
@@ -13,6 +13,11 @@ const PhospherIcon = ({ name, weight, size, color }) => {
   const normalizedName = pascalCase(name);
   const IconToRender = Icon[normalizedName];
 
+  if (!IconToRender) {
+    console.warn(`Icon ${name} not found in Phosphor-React`);
+    return null;
+  }
+
   return <IconToRender color={color} weight={weight} size={size} />;
 };
 


### PR DESCRIPTION
## 🐛 Issue

Phosper is throwing an error on some production feeds because it's rendering icons that no longer exist. 

## ✏️ Solution

Return `null` and log instead of bombinbg. 

## 🔬 To Test


I fixed my broken feed 😬 so I don't have a great reproducible feed to share now. Here's what it looked like: 

<img width="1487" alt="CleanShot 2024-01-25 at 09 39 09@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/90ed591c-e4b5-4426-b9e1-29a3a2cdeb4e">


