### PR TITLE
chore(button feature): better styling of buttons to match mobile

### DIFF
--- a/packages/web-shared/ui-kit/Button/Button.styles.js
+++ b/packages/web-shared/ui-kit/Button/Button.styles.js
@@ -12,23 +12,12 @@ function darken(c, by) {
   return Color(c).darken(by).toString();
 }
 
-const buttonState = ({
-  theme,
-  variant,
-  disabled,
-  focused,
-  hovered,
-  pressed,
-}) => {
+const buttonState = ({ theme, variant, disabled, focused, hovered, pressed }) => {
   if (disabled) {
     return css`
       opacity: 0.5;
-      background: ${variant === 'secondary'
-        ? 'transparent'
-        : theme.colors.base.gray};
-      border: ${variant === 'secondary'
-        ? theme.colors.base.gray
-        : 'transparent'};
+      background: ${variant === 'secondary' ? 'transparent' : theme.colors.base.gray};
+      border: ${variant === 'secondary' ? theme.colors.base.gray : 'transparent'};
       cursor: not-allowed;
     `;
   }
@@ -36,9 +25,7 @@ const buttonState = ({
   if (pressed) {
     return css`
       background: ${theme.colors.base.gray};
-      border: ${variant === 'secondary'
-        ? theme.colors.fill.system
-        : 'transparent'};
+      border: ${variant === 'secondary' ? theme.colors.fill.system : 'transparent'};
       transform: scale(0.98);
     `;
   }
@@ -159,13 +146,7 @@ const buttonColorState = ({ theme, disabled, focused, hovered }) => {
   return null;
 };
 
-const buttonColorStateLink = ({
-  theme,
-  disabled,
-  focused,
-  hovered,
-  variant,
-}) => {
+const buttonColorStateLink = ({ theme, disabled, focused, hovered, variant }) => {
   if (disabled && variant === 'link') {
     return css`
       color: ${theme.colors.text.secondary};
@@ -208,6 +189,8 @@ const Button = withTheme(styled.button`
   border-radius: ${themeGet('radii.xl')};
   cursor: pointer;
   align-items: center;
+  margin-top: 16px;
+  margin-bottom: 16px;
   ${buttonTypeProp}
   ${webTransition}
   ${buttonState}


### PR DESCRIPTION
## 🐛 Issue

Button styling doesn't match mobile
<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

## ✏️ Solution

Add margin around buttons to match mobile
<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Nav to [this link](http://localhost:3000/?id=UniversalContentItem-8aa3cff4-5054-4464-b1dc-e2e31c5adf1d)
2. See buttons properly spaced out

## 📸 Screenshots

| Before | After |
| --- | --- |
| ![Screenshot 2024-01-25 at 12 45 28 PM](https://github.com/ApollosProject/apollos-embeds/assets/72768221/dac83f01-b087-4b5e-8cc1-48ba86791d24) | ![Screenshot 2024-01-25 at 12 45 18 PM](https://github.com/ApollosProject/apollos-embeds/assets/72768221/0682eeec-9558-4032-bcd5-6a6117e3acec) |