### PR TITLE
fix: Stop double scroll issue

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -1,48 +1,20 @@
-import React, { useEffect, useState, useRef, useMemo, createElement, Fragment } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
-import { ClockCounterClockwise, MagnifyingGlass, CaretDown, CaretRight, X } from 'phosphor-react';
+import React, { useEffect, useRef, useMemo } from 'react';
+import { X } from 'phosphor-react';
 
 import algoliasearch from 'algoliasearch/lite';
 import { createAutocomplete } from '@algolia/autocomplete-core';
-import { getAlgoliaResults, parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
+import { getAlgoliaResults } from '@algolia/autocomplete-preset-algolia';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
 import '@algolia/autocomplete-theme-classic';
 
-import { FeatureFeedProvider } from '../../providers';
-import Feed from '../FeatureFeed';
-import { ResourceCard, Box } from '../../ui-kit';
-
 import { useSearchState } from '../../providers/SearchProvider';
-import { getURLFromType } from '../../utils';
 import Styled from './Search.styles';
-import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../providers/BreadcrumbProvider';
-import { open as openModal, set as setModal, useModal } from '../../providers/ModalProvider';
 
 const MOBILE_BREAKPOINT = 428;
-const appId = "Z0GWPR8XBE";
-const apiKey = "251ec8d76f6c62ac793c1337b39bda58";
+const appId = 'Z0GWPR8XBE';
+const apiKey = '251ec8d76f6c62ac793c1337b39bda58';
 const searchClient = algoliasearch(appId, apiKey);
-
-function Hit({ hit }) {
-  return hit?.title;
-}
-
-// Highlight text render
-function Highlight({ hit, attribute, tagName = 'mark' }) {
-  return createElement(
-    Fragment,
-    {},
-    parseAlgoliaHitHighlight({ hit, attribute }).map(({ value, isHighlighted }, index) => {
-      if (isHighlighted) {
-        return createElement(tagName, { key: index }, value);
-      }
-
-      return value;
-    })
-  );
-}
 
 // Recent Searches Index Definition
 const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
@@ -57,124 +29,12 @@ const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
   },
 });
 
-// Query Suggestion Item Render
-function QuerySuggestionItem({ item, autocomplete, handleActionPress }) {
-  return (
-    <Box className="aa-ItemWrapper" px="xs">
-      <div className="aa-ItemContent">
-        <div className="aa-ItemIcon aa-ItemIcon--noBorder">
-          <MagnifyingGlass size={24} weight="bold" />
-        </div>
-        <div className="aa-ItemContentBody">
-          <div className="aa-ItemContentTitle">
-            <Hit hit={item} />
-          </div>
-        </div>
-      </div>
-      <div className="aa-ItemActions">
-        <button
-          className="aa-ItemActionButton"
-          title={`Fill query with "${item.title}"`}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            autocomplete.setQuery(item.title);
-            autocomplete.refresh();
-          }}
-        >
-          <CaretRight size={24} weight="bold" />
-        </button>
-      </div>
-    </Box>
-  );
-}
-
-// Recent Search Item Render
-function PastQueryItem({ item, autocomplete }) {
-  function onRemove(id) {
-    recentSearchesPlugin.data.removeItem(id);
-    autocomplete.refresh();
-  }
-
-  function onTapAhead(item) {
-    autocomplete.setQuery(item.label);
-    autocomplete.setIsOpen(true);
-    autocomplete.refresh();
-  }
-  return (
-    <Box className="aa-ItemWrapper" px="xs">
-      <div className="aa-ItemContent">
-        <div className="aa-ItemIcon aa-ItemIcon--noBorder">
-          <ClockCounterClockwise size={24} weight="bold" />
-        </div>
-        <div className="aa-ItemContentBody">
-          <div className="aa-ItemContentTitle">
-            <Highlight hit={item} attribute="label" />
-          </div>
-        </div>
-      </div>
-      <div className="aa-ItemActions">
-        <button
-          className="aa-ItemActionButton"
-          title="Remove this search"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onRemove(item.id);
-          }}
-        >
-          <svg viewBox="0 0 24 24" fill="currentColor">
-            <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z" />
-          </svg>
-        </button>
-        <button
-          className="aa-ItemActionButton"
-          title={`Fill query with "${item.label}"`}
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            onTapAhead(item);
-          }}
-        >
-          <CaretRight size={24} weight="bold" />
-        </button>
-      </div>
-    </Box>
-  );
-}
-
 export default function Autocomplete({
   autocompleteState,
   setAutocompleteState,
   setShowTextPrompt,
   getAutocompleteInstance,
 }) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const dispatchBreadcrumb = useBreadcrumbDispatch();
-  const [state, dispatch] = useModal();
-
-  const [isResultsEmpty, setIsResultsEmpty] = useState(false);
-
-  const handleActionPress = (item) => {
-    if (searchParams.get('id') !== getURLFromType(item)) {
-      dispatchBreadcrumb(
-        addBreadcrumb({
-          url: `?id=${getURLFromType(item)}`,
-          title: item.title,
-        })
-      );
-      setSearchParams(`?id=${getURLFromType(item)}`);
-    }
-    if (state.modal) {
-      const url = getURLFromType(item);
-      dispatch(setModal(url));
-      dispatch(openModal());
-    }
-  };
-  const handleStaticActionPress = (item) => {
-    window.location.href = item.url;
-  };
-  const navigate = useNavigate();
   const searchState = useSearchState();
   const inputRef = useRef(null);
 
@@ -225,15 +85,6 @@ export default function Autocomplete({
       autocomplete.setQuery(value);
     }
     autocomplete.refresh();
-  };
-
-  const handlePanelDropdown = () => {
-    const updatedAutocompleteState = { ...autocompleteState };
-    updatedAutocompleteState.isOpen = !updatedAutocompleteState.isOpen;
-    setAutocompleteState(updatedAutocompleteState);
-
-    autocomplete.setIsOpen(!autocompleteState.isOpen);
-    inputRef.current?.[autocompleteState.isOpen ? 'blur' : 'focus']();
   };
 
   // Query Suggesion Index Definition
@@ -395,17 +246,6 @@ export default function Autocomplete({
   }, [autocompleteState.isOpen, autocomplete, setShowTextPrompt]);
 
   useEffect(() => {
-    const pagesItems =
-      autocompleteState.collections.find((collection) => collection.source.sourceId === 'pages')
-        ?.items || [];
-    const contentItems =
-      autocompleteState.collections.find((collection) => collection.source.sourceId === 'content')
-        ?.items || [];
-
-    setIsResultsEmpty(pagesItems.length === 0 && contentItems.length === 0);
-  }, [autocompleteState.collections]);
-
-  useEffect(() => {
     if (getAutocompleteInstance) {
       getAutocompleteInstance(autocomplete);
     }
@@ -424,135 +264,6 @@ export default function Autocomplete({
           </div>
         ) : null}
       </form>
-      <Box
-        id="panel"
-        className="aa-Panel"
-        dropdown={autocompleteState.isOpen}
-        {...autocomplete.getPanelProps({})}
-      >
-        {autocompleteState.isOpen && <div id="panel-top"></div>}
-        {isResultsEmpty &&
-          autocompleteState.collections.some((collection) =>
-            ['pages', 'content'].includes(collection.source.sourceId)
-          ) && (
-            <Box
-              padding="xs"
-              fontWeight="500"
-              color="base.gray"
-              textAlign="center"
-              fontStyle="italic"
-            >
-              No results found
-            </Box>
-          )}
-        {autocompleteState.isOpen &&
-          autocompleteState.collections.map((collection, index) => {
-            const { source, items } = collection;
-            // Rendering of Query Suggestions
-            if (
-              ['querySuggestionsPlugin', 'recentSearchesPlugin'].includes(
-                collection.source.sourceId
-              )
-            ) {
-              return (
-                <div key={`source-${index}`} className="aa-Source">
-                  {collection.source.sourceId === 'querySuggestionsPlugin' && !inputProps.value && (
-                    <Box padding="xs" fontWeight="600" color="base.gray">
-                      Trending Searches
-                    </Box>
-                  )}
-                  {collection.source.sourceId === 'recentSearchesPlugin' && (
-                    <Box padding="xs" fontWeight="600" color="base.gray">
-                      Search History
-                    </Box>
-                  )}
-                  <ul className="aa-List" {...autocomplete.getListProps()}>
-                    {items.map((item, index) => (
-                      <li
-                        key={`${item.objectID ? item.objectID : index}-${
-                          collection.source.sourceId
-                        }`}
-                        className="aa-Item"
-                        {...autocomplete.getItemProps({
-                          item,
-                          source,
-                        })}
-                      >
-                        {collection.source.sourceId === 'querySuggestionsPlugin' && (
-                          <QuerySuggestionItem
-                            item={item}
-                            autocomplete={autocomplete}
-                            handleActionPress={handleActionPress}
-                            {...autocomplete.getItemProps({
-                              item,
-                              source,
-                            })}
-                          />
-                        )}
-                        {collection.source.sourceId === 'recentSearchesPlugin' && (
-                          <PastQueryItem
-                            item={item}
-                            autocomplete={autocomplete}
-                            {...autocomplete.getItemProps({
-                              item,
-                              source,
-                            })}
-                          />
-                        )}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              );
-            }
-
-            // Rendering of regular items
-
-            return autocompleteState.query !== '' ? (
-              <div key={`source-${index}`} className="aa-Source">
-                <ul className="aa-List" {...autocomplete.getListProps()}>
-                  {items.map((item) => (
-                    <Box
-                      as="li"
-                      borderRadius="0"
-                      padding="0"
-                      key={item.objectID}
-                      className="aa-Item"
-                      {...autocomplete.getItemProps({
-                        item,
-                        source,
-                      })}
-                    >
-                      <ResourceCard
-                        leadingAsset={item?.coverImage}
-                        title={item?.title}
-                        onClick={() => {
-                          if (collection.source.sourceId === 'pages') {
-                            return handleStaticActionPress(item);
-                          }
-                          return handleActionPress(item);
-                        }}
-                        background="none"
-                      />
-                    </Box>
-                  ))}
-                </ul>
-              </div>
-            ) : null;
-          })}
-        {autocompleteState.isOpen && autocompleteState.query === '' && searchState.searchFeed ? (
-          <Box className="empty-feed">
-            <FeatureFeedProvider
-              Component={Feed}
-              options={{
-                variables: {
-                  itemId: searchState.searchFeed,
-                },
-              }}
-            />
-          </Box>
-        ) : null}
-      </Box>
     </div>
   );
 }

--- a/packages/web-shared/components/Searchbar/Search.styles.js
+++ b/packages/web-shared/components/Searchbar/Search.styles.js
@@ -48,12 +48,9 @@ const showPanel = ({ dropdown }) => {
 };
 
 const Wrapper = withTheme(styled.div`
-  align-items: center;
   background: ${themeGet('colors.base.white')};
   box-shadow: ${themeGet('shadows.medium')};
-  display: flex;
   height: 60px;
-  justify-content: space-between;
   width: 100%;
   z-index: 100;
   ${showDropdown}
@@ -72,6 +69,9 @@ const Wrapper = withTheme(styled.div`
     overflow-x: hidden;
     border-radius: 0px 0px 15px 15px;
     ${showPanel}
+    position: relative;
+    display: inline-block;
+    margin: 0px;
   }
 
   .aa-Form:focus-within {
@@ -91,12 +91,12 @@ const TextPrompt = withTheme(styled.div`
   display: flex;
   overflow: hidden;
   pointer-events: none;
-  position: absolute;
   text-overflow: ellipsis;
   top: 50%;
   transform: translate(0, -50%);
   white-space: nowrap;
   width: 100%;
+  position: absolute;
 
   @media screen and (max-width: ${themeGet('breakpoints.md')}) {
     max-width: 70%;

--- a/packages/web-shared/components/Searchbar/SearchResults.js
+++ b/packages/web-shared/components/Searchbar/SearchResults.js
@@ -1,0 +1,298 @@
+import React, { useEffect, useState, createElement, Fragment } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import '@algolia/autocomplete-theme-classic';
+import { parseAlgoliaHitHighlight } from '@algolia/autocomplete-preset-algolia';
+
+import { useSearchState } from '../../providers/SearchProvider';
+import { FeatureFeedProvider } from '../../providers';
+import Feed from '../FeatureFeed';
+import { ResourceCard, Box } from '../../ui-kit';
+
+import { getURLFromType } from '../../utils';
+import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../providers/BreadcrumbProvider';
+import { open as openModal, set as setModal, useModal } from '../../providers/ModalProvider';
+import { ClockCounterClockwise, MagnifyingGlass, CaretRight, X } from 'phosphor-react';
+
+function Hit({ hit }) {
+  return hit?.title;
+}
+
+// Highlight text render
+function Highlight({ hit, attribute, tagName = 'mark' }) {
+  return createElement(
+    Fragment,
+    {},
+    parseAlgoliaHitHighlight({ hit, attribute }).map(({ value, isHighlighted }, index) => {
+      if (isHighlighted) {
+        return createElement(tagName, { key: index }, value);
+      }
+
+      return value;
+    })
+  );
+}
+
+// Query Suggestion Item Render
+function QuerySuggestionItem({ item, autocomplete, handleActionPress }) {
+  return (
+    <Box className="aa-ItemWrapper" px="xs">
+      <div className="aa-ItemContent">
+        <div className="aa-ItemIcon aa-ItemIcon--noBorder">
+          <MagnifyingGlass size={24} weight="bold" />
+        </div>
+        <div className="aa-ItemContentBody">
+          <div className="aa-ItemContentTitle">
+            <Hit hit={item} />
+          </div>
+        </div>
+      </div>
+      <div className="aa-ItemActions">
+        <button
+          className="aa-ItemActionButton"
+          title={`Fill query with "${item.title}"`}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            autocomplete.setQuery(item.title);
+            autocomplete.refresh();
+          }}
+        >
+          <CaretRight size={24} weight="bold" />
+        </button>
+      </div>
+    </Box>
+  );
+}
+
+// Recent Search Item Render
+function PastQueryItem({ item, autocomplete }) {
+  function onRemove(id) {
+    recentSearchesPlugin.data.removeItem(id);
+    autocomplete.refresh();
+  }
+
+  function onTapAhead(item) {
+    autocomplete.setQuery(item.label);
+    autocomplete.setIsOpen(true);
+    autocomplete.refresh();
+  }
+  return (
+    <Box className="aa-ItemWrapper" px="xs">
+      <div className="aa-ItemContent">
+        <div className="aa-ItemIcon aa-ItemIcon--noBorder">
+          <ClockCounterClockwise size={24} weight="bold" />
+        </div>
+        <div className="aa-ItemContentBody">
+          <div className="aa-ItemContentTitle">
+            <Highlight hit={item} attribute="label" />
+          </div>
+        </div>
+      </div>
+      <div className="aa-ItemActions">
+        <button
+          className="aa-ItemActionButton"
+          title="Remove this search"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onRemove(item.id);
+          }}
+        >
+          <svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M18 7v13c0 0.276-0.111 0.525-0.293 0.707s-0.431 0.293-0.707 0.293h-10c-0.276 0-0.525-0.111-0.707-0.293s-0.293-0.431-0.293-0.707v-13zM17 5v-1c0-0.828-0.337-1.58-0.879-2.121s-1.293-0.879-2.121-0.879h-4c-0.828 0-1.58 0.337-2.121 0.879s-0.879 1.293-0.879 2.121v1h-4c-0.552 0-1 0.448-1 1s0.448 1 1 1h1v13c0 0.828 0.337 1.58 0.879 2.121s1.293 0.879 2.121 0.879h10c0.828 0 1.58-0.337 2.121-0.879s0.879-1.293 0.879-2.121v-13h1c0.552 0 1-0.448 1-1s-0.448-1-1-1zM9 5v-1c0-0.276 0.111-0.525 0.293-0.707s0.431-0.293 0.707-0.293h4c0.276 0 0.525 0.111 0.707 0.293s0.293 0.431 0.293 0.707v1zM9 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1zM13 11v6c0 0.552 0.448 1 1 1s1-0.448 1-1v-6c0-0.552-0.448-1-1-1s-1 0.448-1 1z" />
+          </svg>
+        </button>
+        <button
+          className="aa-ItemActionButton"
+          title={`Fill query with "${item.label}"`}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onTapAhead(item);
+          }}
+        >
+          <CaretRight size={24} weight="bold" />
+        </button>
+      </div>
+    </Box>
+  );
+}
+
+const SearchResults = ({ autocompleteState, autocomplete }) => {
+  const searchState = useSearchState();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dispatchBreadcrumb = useBreadcrumbDispatch();
+  const [state, dispatch] = useModal();
+
+  const [isResultsEmpty, setIsResultsEmpty] = useState(false);
+
+  useEffect(() => {
+    const pagesItems =
+      autocompleteState.collections.find((collection) => collection.source.sourceId === 'pages')
+        ?.items || [];
+    const contentItems =
+      autocompleteState.collections.find((collection) => collection.source.sourceId === 'content')
+        ?.items || [];
+
+    setIsResultsEmpty(pagesItems.length === 0 && contentItems.length === 0);
+  }, [autocompleteState.collections]);
+
+  const handleActionPress = (item) => {
+    if (searchParams.get('id') !== getURLFromType(item)) {
+      dispatchBreadcrumb(
+        addBreadcrumb({
+          url: `?id=${getURLFromType(item)}`,
+          title: item.title,
+        })
+      );
+      setSearchParams(`?id=${getURLFromType(item)}`);
+    }
+    if (state.modal) {
+      const url = getURLFromType(item);
+      dispatch(setModal(url));
+      dispatch(openModal());
+    }
+  };
+
+  const handleStaticActionPress = (item) => {
+    window.location.href = item.url;
+  };
+
+  if (!autocompleteState || !autocomplete) {
+    return null;
+  }
+
+  // Makes SSR consistent on aria aspects
+  const inputProps = autocomplete.getInputProps({});
+
+  return (
+    <Box
+      id="panel"
+      className="aa-Panel"
+      dropdown={autocompleteState.isOpen}
+      {...autocomplete.getPanelProps({})}
+    >
+      {autocompleteState.isOpen && <div id="panel-top"></div>}
+      {isResultsEmpty &&
+        autocompleteState.collections.some((collection) =>
+          ['pages', 'content'].includes(collection.source.sourceId)
+        ) && (
+          <Box
+            padding="xs"
+            fontWeight="500"
+            color="base.gray"
+            textAlign="center"
+            fontStyle="italic"
+          >
+            No results found
+          </Box>
+        )}
+      {autocompleteState.isOpen &&
+        autocompleteState.collections.map((collection, index) => {
+          const { source, items } = collection;
+          // Rendering of Query Suggestions
+          if (
+            ['querySuggestionsPlugin', 'recentSearchesPlugin'].includes(collection.source.sourceId)
+          ) {
+            return (
+              <div key={`source-${index}`} className="aa-Source">
+                {collection.source.sourceId === 'querySuggestionsPlugin' && !inputProps.value && (
+                  <Box padding="xs" fontWeight="600" color="base.gray">
+                    Trending Searches
+                  </Box>
+                )}
+                {collection.source.sourceId === 'recentSearchesPlugin' && (
+                  <Box padding="xs" fontWeight="600" color="base.gray">
+                    Search History
+                  </Box>
+                )}
+                <ul className="aa-List" {...autocomplete.getListProps()}>
+                  {items.map((item, index) => (
+                    <li
+                      key={`${item.objectID ? item.objectID : index}-${collection.source.sourceId}`}
+                      className="aa-Item"
+                      {...autocomplete.getItemProps({
+                        item,
+                        source,
+                      })}
+                    >
+                      {collection.source.sourceId === 'querySuggestionsPlugin' && (
+                        <QuerySuggestionItem
+                          item={item}
+                          autocomplete={autocomplete}
+                          handleActionPress={handleActionPress}
+                          {...autocomplete.getItemProps({
+                            item,
+                            source,
+                          })}
+                        />
+                      )}
+                      {collection.source.sourceId === 'recentSearchesPlugin' && (
+                        <PastQueryItem
+                          item={item}
+                          autocomplete={autocomplete}
+                          {...autocomplete.getItemProps({
+                            item,
+                            source,
+                          })}
+                        />
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          }
+
+          // Rendering of regular items
+
+          return autocompleteState.query !== '' ? (
+            <div key={`source-${index}`} className="aa-Source">
+              <ul className="aa-List" {...autocomplete.getListProps()}>
+                {items.map((item) => (
+                  <Box
+                    as="li"
+                    borderRadius="0"
+                    padding="0"
+                    key={item.objectID}
+                    className="aa-Item"
+                    {...autocomplete.getItemProps({
+                      item,
+                      source,
+                    })}
+                  >
+                    <ResourceCard
+                      leadingAsset={item?.coverImage}
+                      title={item?.title}
+                      onClick={() => {
+                        if (collection.source.sourceId === 'pages') {
+                          return handleStaticActionPress(item);
+                        }
+                        return handleActionPress(item);
+                      }}
+                      background="none"
+                    />
+                  </Box>
+                ))}
+              </ul>
+            </div>
+          ) : null;
+        })}
+      {autocompleteState.isOpen && autocompleteState.query === '' && searchState.searchFeed ? (
+        <Box className="empty-feed">
+          <FeatureFeedProvider
+            Component={Feed}
+            options={{
+              variables: {
+                itemId: searchState.searchFeed,
+              },
+            }}
+          />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+export default SearchResults;

--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -157,8 +157,8 @@ const Searchbar = (props = {}) => {
           </Box>
         </Box>
         <SearchResults autocompleteState={autocompleteState} autocomplete={autocompleteInstance} />
-        {showProfile ? <Profile handleCloseProfile={handleCloseProfile} /> : null}
       </Styled.Wrapper>
+      {showProfile ? <Profile handleCloseProfile={handleCloseProfile} /> : null}
     </Box>
   );
 };

--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -9,6 +9,7 @@ import { useSearchState } from '../../providers/SearchProvider';
 
 import Profile from '../Profile';
 import Autocomplete from '../Searchbar/Autocomplete';
+import SearchResults from '../Searchbar/SearchResults';
 
 import Styled from './Search.styles';
 
@@ -122,40 +123,42 @@ const Searchbar = (props = {}) => {
       {...props}
     >
       <Styled.Wrapper dropdown={autocompleteState.isOpen}>
-        <Styled.Interface>
-          <Styled.InterfaceWrapper>
-            <Box padding="12px" onClick={handleClick}>
-              <Styled.SearchIcon>
-                {isMobile && autocompleteState.isOpen ? (
-                  <ArrowLeft size={18} weight="bold" color={userExist ? 'white' : null} />
-                ) : (
-                  <MagnifyingGlass size={18} weight="bold" color={userExist ? 'white' : null} />
-                )}
-              </Styled.SearchIcon>
-            </Box>
-            <Box width="100%">
-              <Autocomplete
-                autocompleteState={autocompleteState}
-                setAutocompleteState={setAutocompleteState}
-                setShowTextPrompt={setShowTextPrompt}
-                getAutocompleteInstance={handleGetAutocompleteInstance}
-              />
-              {showTextPrompt ? textPrompt : null}
-            </Box>
-          </Styled.InterfaceWrapper>
-        </Styled.Interface>
-        <Box padding="12px" onClick={handleOpenProfile}>
-          {currentUser?.profile?.photo?.uri ? (
-            <Avatar src={currentUser?.profile?.photo?.uri} width="38px" alt="avatar" />
-          ) : (
-            <Styled.Profile>
-              <User size={18} weight="bold" color={userExist ? 'white' : null} />
-            </Styled.Profile>
-          )}
+        <Box display="flex" flexDirection="row" h="60px" w="100%">
+          <Styled.Interface>
+            <Styled.InterfaceWrapper>
+              <Box padding="12px" onClick={handleClick}>
+                <Styled.SearchIcon>
+                  {isMobile && autocompleteState.isOpen ? (
+                    <ArrowLeft size={18} weight="bold" color={userExist ? 'white' : null} />
+                  ) : (
+                    <MagnifyingGlass size={18} weight="bold" color={userExist ? 'white' : null} />
+                  )}
+                </Styled.SearchIcon>
+              </Box>
+              <Box width="100%">
+                <Autocomplete
+                  autocompleteState={autocompleteState}
+                  setAutocompleteState={setAutocompleteState}
+                  setShowTextPrompt={setShowTextPrompt}
+                  getAutocompleteInstance={handleGetAutocompleteInstance}
+                />
+                {showTextPrompt ? textPrompt : null}
+              </Box>
+            </Styled.InterfaceWrapper>
+          </Styled.Interface>
+          <Box padding="12px" onClick={handleOpenProfile}>
+            {currentUser?.profile?.photo?.uri ? (
+              <Avatar src={currentUser?.profile?.photo?.uri} width="38px" alt="avatar" />
+            ) : (
+              <Styled.Profile>
+                <User size={18} weight="bold" color={userExist ? 'white' : null} />
+              </Styled.Profile>
+            )}
+          </Box>
         </Box>
+        <SearchResults autocompleteState={autocompleteState} autocomplete={autocompleteInstance} />
+        {showProfile ? <Profile handleCloseProfile={handleCloseProfile} /> : null}
       </Styled.Wrapper>
-
-      {showProfile ? <Profile handleCloseProfile={handleCloseProfile} /> : null}
     </Box>
   );
 };

--- a/web-embeds/public/index.html
+++ b/web-embeds/public/index.html
@@ -1,21 +1,19 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web embed created using The Apollos Project"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web embed created using The Apollos Project" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,30 +22,31 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Apollos Web Embeds</title>
-    <style>
-      body {
-        font-family:
-          "Inter",
-          -apple-system,
-          BlinkMacSystemFont,
-          Segoe UI,
-          Roboto,
-          Oxygen,
-          Ubuntu,
-          Cantarell,
-          Fira Sans,
-          Droid Sans,
-          Helvetica Neue,
-          sans-serif;
-      }
-    </style>
-  </head>
+  <title>Apollos Web Embeds</title>
+  <style>
+    body {
+      font-family:
+        "Inter",
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Roboto,
+        Oxygen,
+        Ubuntu,
+        Cantarell,
+        Fira Sans,
+        Droid Sans,
+        Helvetica Neue,
+        sans-serif;
+      background-color: aqua;
+    }
+  </style>
+</head>
 
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <!-- This is an example of how to use the apollos widgets -->
-    <!-- <div
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <!-- This is an example of how to use the apollos widgets -->
+  <!-- <div
       data-church="cedar_creek"
       data-type="FeatureFeed"
       data-feature-feed="FeatureFeed:5aae43e6-3526-4cd2-8dfe-771d2ce8a333"
@@ -57,7 +56,7 @@
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
 
-    <!-- <div
+  <!-- <div
       data-type="FeatureFeed"
       data-church="liquid_church"
       data-feature-feed="FeatureFeed:d292fd8c-5b9f-4cd7-a2fe-9d7d0914c34f"
@@ -65,23 +64,20 @@
       data-modal="true"
       class="apollos-widget"
     ></div> -->
-    <!-- 
-    <div
-      data-church="cedar_creek"
-      data-type="Search"
-      data-search-feed="FeatureFeed:33b34f30-e57c-4c23-9f28-24d31959a3f4"
-      data-modal="true"
-      class="apollos-widget"
-      style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
-    ></div> -->
-    <div
+  <div data-church="cedar_creek" data-type="Search" data-search-feed="FeatureFeed:33b34f30-e57c-4c23-9f28-24d31959a3f4"
+    data-modal="true" class="apollos-widget" style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px">
+  </div>
+  <div style="height: 1000px; border: 1px solid red; width: 50vw;">
+
+  </div>
+  <!-- <div
       data-church="bayside"
       data-type="Auth"
       data-modal="true"
       class="apollos-widget"
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
-    ></div>
-    <!--
+    ></div> -->
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -91,5 +87,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
## 🐛 Issue

With the search modal open, it was possible to scroll on the page itself instead of in the modal alone. 

## ✏️ Solution

This was a complex issue to solve. The results list was nested inside of the search input, meaning that it's rendering was technically an `overflow` of the search input. 

To resolve this, I moved the result list outside of the search input, meaning that it properly captured scroll events instead of letting them pass through.

In order to move the result list, I had to move break apart the `Autocomplete` component, hence the large number of lines changed. 

## 🔬 To Test

1. I made a mess of `index.html` to demonstrate the issue. I'll roll it back after you test, if you want :) 
2. I recommend using `ngrok` to test on your phone as well. 

## 📸 Screenshots

![image](https://github.com/ApollosProject/apollos-embeds/assets/1637694/a7a87654-63a0-4d97-9274-bea78f501ccd)
<img width="823" alt="CleanShot 2024-01-26 at 12 22 11@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/b3697522-bd4c-4e54-ad42-e65b2c7a2820">

<img width="858" alt="CleanShot 2024-01-26 at 12 22 08@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/eb1a2605-dcf7-461e-bcf2-cccbb0dfe363">
