### PR TITLE
Auto flush cdn cache

### DIFF
--- a/web-embeds/README.md
+++ b/web-embeds/README.md
@@ -9,9 +9,6 @@ Follow the steps below to deploy your apollos-embeds:
 ## Automated
 
 1. Run `npm bump`
-2. Go to https://www.jsdelivr.com/tools/purge and paste in the following to purge the cache on jsdelivr. Otherwise, it could take up to seven days to see our changes in client sites.
-
-`https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds@latest/widget/index.js, https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds@latest/widget/index.css, https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds`
 
 ## Manual
 
@@ -19,7 +16,9 @@ Follow the steps below to deploy your apollos-embeds:
 2. Run `yarn build` to build the new version of the widget.
 3. Commit and push the new JS and CSS build files to GitHub.
 4. Then, run `npm publish`. Note that you need to be a member of the apollosproject organization to publish.
-5. See instructions above to purge cache.
+5. Go to https://www.jsdelivr.com/tools/purge and paste in the following to purge the cache on jsdelivr. Otherwise, it could take up to seven days to see our changes in client sites.
+
+`https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds@latest/widget/index.js, https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds@latest/widget/index.css, https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds`
 
 The JS file used to embed these widgets is hosted on GitHub and picked up by [jsdelivr.com](https://www.jsdelivr.com/) automatically, as long as the repository is public.
 

--- a/web-embeds/flush-cdn-cache.sh
+++ b/web-embeds/flush-cdn-cache.sh
@@ -1,0 +1,10 @@
+curl -X POST \
+  https://purge.jsdelivr.net/ \
+  -H 'content-type: application/json' \
+  -d '{
+        "path": [
+          "/npm/@apollosproject/apollos-embeds@latest/widget/index.js",
+          "/npm/@apollosproject/apollos-embeds@latest/widget/index.css",
+          "/npm/@apollosproject/apollos-embeds"
+        ]
+      }'

--- a/web-embeds/package.json
+++ b/web-embeds/package.json
@@ -60,9 +60,10 @@
     "dev": "craco start",
     "build": "node scripts/build.js",
     "test": "craco test",
-    "bump": "npm version patch && yarn build && git add . && git commit -m 'version bump' && git push && git push --tags && npm publish",
+    "bump": "npm version patch && yarn build && git add . && git commit -m 'version bump' && git push && git push --tags && npm publish && npm run flush-cdn",
     "format": "prettier --write .",
-    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint ."
+    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
+    "flush-cdn": "./flush-cdn-cache.sh"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## 🐛 Issue

Flushing the cache after deploying is annoying.

## ✏️ Solution

Do it automatically. 

## 🔬 To Test


1. `yarn flush-cdn-cache`

## 📸 Screenshots
<img width="609" alt="CleanShot 2024-01-26 at 20 18 41@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/20a33bea-f787-4f99-a179-e517746531e4">
