### PR TITLE
feat: Render a full feed on content items. 

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -12,7 +12,7 @@ import { add as addBreadcrumb, useBreadcrumbDispatch } from '../providers/Breadc
 import { set as setModal, useModal } from '../providers/ModalProvider';
 
 import { Box, Loader, Longform, H3, ContentCard, BodyText, ShareButton } from '../ui-kit';
-import { useHTMLContent, useVideoMediaProgress } from '../hooks';
+import { useFeatureFeed, useHTMLContent, useVideoMediaProgress } from '../hooks';
 import { Title, ParentTitle, ParentSummary } from './ContentSingle.styles';
 
 import VideoPlayer from './VideoPlayer';
@@ -26,6 +26,17 @@ function ContentSingle(props = {}) {
   const dispatchBreadcrumb = useBreadcrumbDispatch();
   const [state, dispatch] = useModal();
   const parseHTMLContent = useHTMLContent();
+
+  const feedId = props?.data?.featureFeed?.id;
+  const {
+    feedLoading,
+    feedError,
+    data: feedData,
+  } = useFeatureFeed({
+    variables: {
+      itemId: feedId,
+    },
+  });
 
   const invalidPage = !props.loading && !props.data;
 
@@ -70,7 +81,6 @@ function ContentSingle(props = {}) {
     parentChannel,
     childContentItemsConnection,
     siblingContentItemsConnection,
-    featureFeed,
     parentItem,
   } = props?.data;
 
@@ -79,7 +89,9 @@ function ContentSingle(props = {}) {
   const hasChildContent = childContentItems?.length > 0;
   const hasSiblingContent = siblingContentItems?.length > 0;
   const hasParent = !!parentItem;
-  const validFeatures = featureFeed?.features?.filter(
+
+  const feed = feedData?.node;
+  const validFeatures = feed?.features?.filter(
     (feature) => !!FeatureFeedComponentMap[feature?.__typename]
   );
   const hasFeatures = validFeatures?.length;
@@ -342,7 +354,7 @@ function ContentSingle(props = {}) {
         {/* Sub-Feature Feed */}
         {hasFeatures ? (
           <Box my="l">
-            <FeatureFeed data={featureFeed} />
+            <FeatureFeed data={feed} />
           </Box>
         ) : null}
       </Box>

--- a/packages/web-shared/hooks/useContentItem.js
+++ b/packages/web-shared/hooks/useContentItem.js
@@ -88,62 +88,6 @@ export const GET_CONTENT_ITEM = gql`
         ... on FeaturesNode {
           featureFeed {
             id
-            features {
-              id
-              ... on HorizontalCardListFeature {
-                title
-                cards {
-                  id
-                  title
-                  summary
-                  coverImage {
-                    name
-                    sources {
-                      uri
-                    }
-                  }
-                  hasAction
-                  action
-                  actionIcon
-                  relatedNode {
-                    id
-                    __typename
-                    ... on ContentItem {
-                      title
-                    }
-                    ... on Url {
-                      url
-                    }
-                  }
-                }
-              }
-              ... on ButtonFeature {
-                action {
-                  title
-                  action
-                  relatedNode {
-                    id
-                    __typename
-                    ... on Url {
-                      url
-                    }
-                  }
-                }
-              }
-              ... on HtmlFeature {
-                content
-              }
-              ... on ScriptureFeature {
-                scriptures {
-                  id
-                  html
-                  reference
-                  copyright
-                  version
-                  text
-                }
-              }
-            }
           }
         }
       }

--- a/packages/web-shared/hooks/useFeatureFeed.js
+++ b/packages/web-shared/hooks/useFeatureFeed.js
@@ -268,6 +268,32 @@ export const FEED_FEATURES = gql`
               }
             }
           }
+          ... on ButtonFeature {
+            action {
+              title
+              action
+              relatedNode {
+                id
+                __typename
+                ... on Url {
+                  url
+                }
+              }
+            }
+          }
+          ... on HtmlFeature {
+            content
+          }
+          ... on ScriptureFeature {
+            scriptures {
+              id
+              html
+              reference
+              copyright
+              version
+              text
+            }
+          }
         }
       }
     }

--- a/web-embeds/public/index.html
+++ b/web-embeds/public/index.html
@@ -72,12 +72,11 @@
       class="apollos-widget"
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
+
   <div data-type="FeatureFeed" data-church="liquid_church"
-    data-feature-feed="FeatureFeed:04160599-4edf-4824-98c5-02c1a8854c48" data-modal="true" class="apollos-widget">
-  </div>
-  <div data-type="FeatureFeed" data-church="liquid_church"
-    data-feature-feed="FeatureFeed:e5d913ee-0f28-45a3-8f71-f5ce2ae6cb3b" data-modal="true" class="apollos-widget">
-  </div>
+    data-feature-feed="FeatureFeed:d3912726-487b-4635-9cec-99ed84a21209" data-modal="true" class="apollos-widget"></div>
+
+
   <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION
## 🐛 Issue

We should render any features we support on a content item, not just features specifically queried for by the content item query. 

Provides support for: https://3.basecamp.com/3926363/buckets/32694519/card_tables/cards/6979833101

## ✏️ Solution

Use the featureFeed hook to query for a content item's features, rather than relying on a subquery of `contentItem` 

## 🔬 To Test

1. start web embeds
2. visit [this item](http://localhost:3000/?id=a-fresh-anointing-TWVkaWFDb250ZW50SXRlbS0wZjYwYmJiMy1mNWRlLTRjODMtYjk2MS1kOTg2NDM2NWYwMDk%3D)
3. You will see an action bar feature at the bottom

## 📸 Screenshots

<img width="1088" alt="CleanShot 2024-01-29 at 16 03 18@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/e6be8eae-590f-4e0b-a79c-0089aa7e66a9">

