### PR TITLE
fix: search not redirecting with keyboard input

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -159,7 +159,11 @@ export default function Autocomplete({
               });
             },
             getItemUrl({ item }) {
-              return `/?query=${item.name}`;
+              if (item?.name) {
+                return `/?query=${item.name}`;
+              } else {
+                return item.url;
+              }
             },
           },
           {


### PR DESCRIPTION
## 🐛 Issue

issue - https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6948796088

## ✏️ Solution

Fix navigation on algolia search

## 🔬 To Test

1. set configuration to search
2. select item in search result using keyboard
3. check for correct navigation

## 📸 Screenshots


https://github.com/ApollosProject/apollos-embeds/assets/28708210/5d06f24b-d638-477b-960e-1f31419b64e4



