### PR TITLE
fix: search not redirecting with keyboard input

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -9,6 +9,7 @@ import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-pl
 import '@algolia/autocomplete-theme-classic';
 
 import { useSearchState } from '../../providers/SearchProvider';
+import { getURLFromType } from '../../utils';
 import Styled from './Search.styles';
 
 const MOBILE_BREAKPOINT = 428;
@@ -189,7 +190,11 @@ export default function Autocomplete({
               });
             },
             getItemUrl({ item }) {
-              return `/?query=${item.name}`;
+              if (item?.name) {
+                return `/?query=${item.name}`;
+              } else {
+                return `?id=${getURLFromType(item)}`;
+              }
             },
           },
         ];

--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -159,7 +159,11 @@ export default function Autocomplete({
               });
             },
             getItemUrl({ item }) {
-              return `/?query=${item.name}`;
+              if (item?.name) {
+                return `/?query=${item.name}`;
+              } else {
+                return item.url;
+              }
             },
           },
           {


### PR DESCRIPTION
## 🐛 Issue

Issue - https://3.basecamp.com/3926363/buckets/27088350/card_tables/cards/6948796088

## ✏️ Solution

Fix content item navigation on algolia search

## 🔬 To Test

1. set configuration to search
2. select item in search result using keyboard
3. check for correct navigation

## 📸 Screenshots

https://github.com/ApollosProject/apollos-embeds/assets/28708210/ab051837-5caa-44ec-994e-34cf963ec6aa



