### PR TITLE
chore: Move feature feed above parent child card

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -238,6 +238,12 @@ function ContentSingle(props = {}) {
             </>
           ) : null}
         </Box>
+        {/* Sub-Feature Feed */}
+        {hasFeatures ? (
+          <Box my="l">
+            <FeatureFeed data={feed} />
+          </Box>
+        ) : null}
         {/* Display content for series */}
         {hasChildContent ? (
           <Box mb="l">
@@ -349,13 +355,6 @@ function ContentSingle(props = {}) {
               </Box>
             </Box>
           </>
-        ) : null}
-
-        {/* Sub-Feature Feed */}
-        {hasFeatures ? (
-          <Box my="l">
-            <FeatureFeed data={feed} />
-          </Box>
         ) : null}
       </Box>
     </>


### PR DESCRIPTION
## 🐛 Issue

The feature feed on WebEmbeds is currently below the content/parent item section. 

https://3.basecamp.com/3926363/buckets/32694519/card_tables/cards/6979833101

## ✏️ Solution

Move it above the parent

## 🔬 To Test

http://localhost:3000/?id=in-training-for-reigning-TWVkaWFDb250ZW50SXRlbS1kODI0Yjg0ZS00MDFkLTQ0NzAtOGFlNi1mYjU3Y2U4NWUwMmI%3D

## 📸 Screenshots
![CleanShot 2024-02-05 at 12 46 01@2x](https://github.com/ApollosProject/apollos-embeds/assets/1637694/4c5f2883-9c26-409b-a97d-97fade9975ed)


