### PR TITLE
fix: Make logo narrower on small screens

### DIFF
--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -77,6 +77,7 @@ const Modal = (props = {}) => {
                 alignItems="center"
                 justifyContent="center"
                 flexDirection={{ _: 'column-reverse', sm: 'row' }}
+                maxWidth={{ _: '100%', xs: '70%' }}
               >
                 <ChurchLogo
                   display="flex"


### PR DESCRIPTION
## 🐛 Issue

Logo is too wide on small screens.

## ✏️ Solution

Make logo narrower on small screens.

## 🔬 To Test

http://localhost:3000/?id=in-training-for-reigning-TWVkaWFDb250ZW50SXRlbS1kODI0Yjg0ZS00MDFkLTQ0NzAtOGFlNi1mYjU3Y2U4NWUwMmI%3D

## 📸 Screenshots

<img width="603" alt="CleanShot 2024-02-05 at 13 02 42@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/174b9966-c127-442f-b460-b3225a22448c">
<img width="517" alt="CleanShot 2024-02-05 at 13 02 29@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/96a22285-ce22-4ecb-920c-93d5022fb35a">
<img width="1501" alt="CleanShot 2024-02-05 at 13 02 21@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/67295056-3f5c-4400-bdd6-7d251fc6aa78">
