### PR TITLE
Tighten spacing on content single

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -126,6 +126,8 @@ function ContentSingle(props = {}) {
     </BodyText>
   );
 
+  console.log('rendering....', siblingContentItems);
+
   return (
     <>
       {/* TODO: Max width set to 750px due to low resolution pictures. Can be increased as higher quality images are used */}
@@ -251,7 +253,7 @@ function ContentSingle(props = {}) {
 
             <Box
               display="grid"
-              gridGap="100px 30px"
+              gridGap="30px 30px"
               gridTemplateColumns={{
                 _: 'repeat(1, minmax(0, 1fr));',
                 md: 'repeat(2, minmax(0, 1fr));',
@@ -269,6 +271,7 @@ function ContentSingle(props = {}) {
                   summary={item.node?.summary}
                   onClick={() => handleActionPress(item.node)}
                   videoMedia={item.node?.videos?.[0]}
+                  channelLabel={item.node?.parentItem?.title}
                 />
               ))}
             </Box>
@@ -332,7 +335,7 @@ function ContentSingle(props = {}) {
               <H3 mb="xs">{props.feature?.title}</H3>
               <Box
                 display="grid"
-                gridGap="100px 30px"
+                gridGap="30px 30px"
                 gridTemplateColumns={{
                   _: 'repeat(1, minmax(0, 1fr));',
                   md: 'repeat(2, minmax(0, 1fr));',
@@ -350,6 +353,7 @@ function ContentSingle(props = {}) {
                     summary={item.node?.summary}
                     onClick={() => handleActionPress(item.node)}
                     videoMedia={item.node?.videos[0]}
+                    channelLabel={item.node?.parentItem?.title}
                   />
                 ))}
               </Box>

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -126,7 +126,6 @@ function ContentSingle(props = {}) {
     </BodyText>
   );
 
-  console.log('rendering....', siblingContentItems);
 
   return (
     <>

--- a/packages/web-shared/hooks/useContentItem.js
+++ b/packages/web-shared/hooks/useContentItem.js
@@ -21,6 +21,9 @@ export const GET_CONTENT_ITEM = gql`
         uri
       }
     }
+    parentItem {
+      title
+    }
     videos {
       ...VideoMediaFields
     }

--- a/packages/web-shared/ui-kit/ContentCard/ContentCard.js
+++ b/packages/web-shared/ui-kit/ContentCard/ContentCard.js
@@ -7,29 +7,39 @@ import { useVideoMediaProgress } from '../../hooks';
 import { getPercentWatched } from '../../utils';
 import { BottomSlot, CompleteIndicator, Title, Summary, ChannelLabel } from './ContentCard.styles';
 
-function ContentCard(props = {}) {
+function ContentCard({
+  videoMedia,
+  image,
+  title,
+  subtitle,
+  summary,
+  channelLabel,
+  horizontal,
+  onClick,
+  ...props
+}) {
   const { userProgress, loading: videoProgressLoading } = useVideoMediaProgress({
-    variables: { id: props.videoMedia?.id },
-    skip: !props.videoMedia?.id,
+    variables: { id: videoMedia?.id },
+    skip: !videoMedia?.id,
   });
 
   const percentWatched = getPercentWatched({
-    duration: props.videoMedia?.duration,
+    duration: videoMedia?.duration,
     userProgress,
   });
 
   return (
     <Box
       flex={1}
-      cursor={props.onClick ? 'pointer' : 'default'}
+      cursor={onClick ? 'pointer' : 'default'}
       borderRadius="xl"
       overflow="hidden"
       backgroundColor="neutral.gray6"
       height="100%"
-      display={props.horizontal ? 'flex' : ''}
+      display={horizontal ? 'flex' : ''}
       {...props}
     >
-      <Box position="relative" width={props.horizontal ? '50%' : ''}>
+      <Box position="relative" width={horizontal ? '50%' : ''}>
         {/* Image */}
         <Box
           backgroundSize="cover"
@@ -37,9 +47,7 @@ function ContentCard(props = {}) {
           backgroundPosition="center"
           backgroundRepeat="no-repeat"
           backgroundColor="material.regular"
-          backgroundImage={`url(${
-            props.image?.sources[0].uri ? props.image.sources[0].uri : null
-          })`}
+          backgroundImage={`url(${image?.sources[0].uri ? image.sources[0].uri : null})`}
           height="100%"
         />
         {/* Progress / Completed Indicators */}
@@ -54,13 +62,11 @@ function ContentCard(props = {}) {
         </BottomSlot>
       </Box>
       {/* Masthead */}
-      <Box padding="base" backdropFilter="blur(64px)" width={props.horizontal ? '50%' : ''}>
-        {props.channelLabel ? (
-          <ChannelLabel color="text.secondary">{props.channelLabel}</ChannelLabel>
-        ) : null}
-        <SmallBodyText color="text.secondary">{props.subtitle}</SmallBodyText>
-        <Title>{props.title}</Title>
-        <Summary color="text.secondary">{props.summary} </Summary>
+      <Box padding="base" backdropFilter="blur(64px)" width={horizontal ? '50%' : ''}>
+        {channelLabel ? <ChannelLabel color="text.secondary">{channelLabel}</ChannelLabel> : null}
+        <SmallBodyText color="text.secondary">{subtitle}</SmallBodyText>
+        <Title>{title}</Title>
+        <Summary color="text.secondary">{summary} </Summary>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## 🐛 Issue

Two issues resolved here: 

- Spacing on card sibling/child items is too loosy-goosy
- Liquid wants to show an item's parent on the parent/sibling view.


## ✏️ Solution

- Tighten spacing on sibling/child items.
- Show an item's parent on the sibling/parent view. 

## 🔬 To Test

http://localhost:3000/?id=facing-your-saul-TWVkaWFDb250ZW50SXRlbS0wNzgwMWQ0Ni1iYWE4LTQ0ZGUtODEwNi1jMThlODA5YmNlZWI%3D

## 📸 Screenshots
<img width="891" alt="CleanShot 2024-02-07 at 11 14 05@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/b9293c57-549b-40a1-8c46-2906d3dfb082">

<img width="424" alt="CleanShot 2024-02-07 at 11 14 28@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/78ff41c9-74e9-4a85-9021-dde90e282528">

