### PR TITLE
feat: Clean Up Chip List Feature

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/ActionBarFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ActionBarFeature.js
@@ -4,13 +4,13 @@ import { systemPropTypes, PhospherIcon } from '../../../ui-kit';
 import Styled from './ActionBarFeature.styles';
 
 function ActionBarFeature(props = {}) {
-  const handleActionPress = url => {
+  const handleActionPress = (url) => {
     window.open(props.transformLink(url), '_blank');
   };
 
   return (
-    <Styled.ActionBar>
-      {props.feature?.actions?.map(item => {
+    <Styled.ActionBar class="chip-list-feature">
+      {props.feature?.actions?.map((item) => {
         return (
           <Styled.ActionBarItem flex="1" onClick={() => handleActionPress(item?.relatedNode?.url)}>
             <PhospherIcon name={item.icon} size={30} />

--- a/packages/web-shared/components/FeatureFeed/Features/ActionBarFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ActionBarFeature.js
@@ -9,7 +9,7 @@ function ActionBarFeature(props = {}) {
   };
 
   return (
-    <Styled.ActionBar class="chip-list-feature">
+    <Styled.ActionBar>
       {props.feature?.actions?.map((item) => {
         return (
           <Styled.ActionBarItem flex="1" onClick={() => handleActionPress(item?.relatedNode?.url)}>

--- a/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.js
@@ -1,8 +1,7 @@
 import React from 'react';
 
-import { systemPropTypes, Box } from '../../../ui-kit';
+import { systemPropTypes, Box, PhospherIcon } from '../../../ui-kit';
 import Styled from './ChipListFeature.styles';
-import { ArrowUpRight } from 'phosphor-react';
 
 function ChipListFeature(props = {}) {
   if (props?.feature?.chips?.length === 0 || !props?.feature?.chips) {
@@ -10,33 +9,20 @@ function ChipListFeature(props = {}) {
   }
 
   return (
-    <Box>
+    <Box className="chip-list-feature">
       <Box padding="xs" fontWeight="600" color="base.gray" id="results">
         {props.feature.title || props.feature.subtitle}
       </Box>
       <Styled.List>
         {props.feature?.chips?.map(({ title, iconName, relatedNode }, index) => {
-          if (index === 0) {
-            return (
-              <Styled.Chip ml="xs" href={relatedNode.url} key={index}>
-                <ArrowUpRight size={20} weight="bold" color="#8E8E93" />
-                <span>{title}</span>
-              </Styled.Chip>
-            );
-          }
-
-          if (index === props.feature?.chips.length - 1) {
-            return (
-              <Styled.Chip mr="xs" href={relatedNode.url} key={index}>
-                <ArrowUpRight size={20} weight="bold" color="#8E8E93" />
-                <span>{title}</span>
-              </Styled.Chip>
-            );
-          }
-
           return (
             <Styled.Chip href={relatedNode.url} key={index}>
-              <ArrowUpRight size={20} weight="bold" color="#8E8E93" />
+              <PhospherIcon
+                name={iconName || 'arrow-up-right'}
+                size={20}
+                weight="bold"
+                color="#8E8E93"
+              />
               <span>{title}</span>
             </Styled.Chip>
           );

--- a/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.styles.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.styles.js
@@ -6,6 +6,7 @@ import { TypeStyles } from '../../../ui-kit/Typography';
 import { system } from '../../../ui-kit/_lib/system';
 
 const Chip = withTheme(styled.a`
+  ${TypeStyles.BodyText}
   display: flex;
   align-items: center;
   justify-content: center;
@@ -17,6 +18,7 @@ const Chip = withTheme(styled.a`
   padding: 6px 10px;
   white-space: nowrap;
   cursor: pointer;
+  text-decoration: none;
 
   &:hover {
     background: rgba(103, 103, 134, 0.2);
@@ -30,6 +32,9 @@ const List = withTheme(styled.ul`
   overflow-x: scroll;
   width: 100%;
   gap: 8px;
+  // Reset ul margin
+  margin-block-start: 0;
+  padding-inline-start: 0;
 
   scrollbar-width: thin; /* For Firefox */
   -ms-overflow-style: none; /* For Internet Explorer and Edge */

--- a/packages/web-shared/components/Searchbar/Search.styles.js
+++ b/packages/web-shared/components/Searchbar/Search.styles.js
@@ -83,6 +83,15 @@ const Wrapper = withTheme(styled.div`
   .aa-Item {
     border-radius: 0;
   }
+
+  .chip-list-feature {
+    * > &:first-child {
+      margin-left: 1rem;
+    }
+    * > &:last-child {
+      margin-left: 1rem;
+    }
+  }
 `);
 
 const TextPrompt = withTheme(styled.div`

--- a/packages/web-shared/ui-kit/ContentCard/ContentCard.js
+++ b/packages/web-shared/ui-kit/ContentCard/ContentCard.js
@@ -37,6 +37,7 @@ function ContentCard({
       backgroundColor="neutral.gray6"
       height="100%"
       display={horizontal ? 'flex' : ''}
+      onClick={onClick}
       {...props}
     >
       <Box position="relative" width={horizontal ? '50%' : ''}>


### PR DESCRIPTION
## 🐛 Issue

The ChipListFeature currently doesn't render well on content items (or non search feeds)

## ✏️ Solution

Style the chip list correctly
  - Style like a chip, remove the "linky" bits.
  - Remove the margin when rendering on a feed
  - But add that margin back in when inside a searchbar. tricky! 

## 🔬 To Test

1. Inspect the chip list on the web embeds index, by clicking search and scrolling down.
3. Insect the chip list [on a content item](http://localhost:3000/?id=in-training-for-reigning-TWVkaWFDb250ZW50SXRlbS1kODI0Yjg0ZS00MDFkLTQ0NzAtOGFlNi1mYjU3Y2U4NWUwMmI%3D)

## 📸 Screenshots
<img width="641" alt="CleanShot 2024-02-07 at 15 40 48@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/3f3a74b0-2db9-4e59-82a1-30c47e0e725b">
<img width="680" alt="CleanShot 2024-02-07 at 15 40 34@2x" src="https://github.com/ApollosProject/apollos-embeds/assets/1637694/b6ec192d-8ce4-46bc-a945-264785e0b2ed">

