### PR TITLE
chore: Bypass caching across all environments

### DIFF
--- a/micro-service/README.md
+++ b/micro-service/README.md
@@ -68,7 +68,7 @@ _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique
 
 ### Disabling Caching for Local Testing
 
-For local development and testing purposes, you might want to disable caching to ensure you're receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
+For local development and testing purposes, you might want to enable caching to ensure you're not receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
 
 [../packages/web-shared/client/apollosApiLink.js](../packages/web-shared/client/apollosApiLink.js)
 

--- a/micro-service/README.md
+++ b/micro-service/README.md
@@ -75,7 +75,7 @@ For local development and testing purposes, you might want to enable caching to 
 In this file, locate the header configuration within the `apollosApiLink` function and comment the following line:
 
 ```javascript
-// 'x-cache-me-not': 1,
+'x-cache-me-not': 1,
 
 
 ### Options

--- a/micro-service/README.md
+++ b/micro-service/README.md
@@ -66,6 +66,18 @@ For the 'FeatureFeed' embed, which displays the church's content, add `data-type
 
 _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique identifier, or 'slug'._
 
+### Disabling Caching for Local Testing
+
+For local development and testing purposes, you might want to disable caching to ensure you're receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
+
+[../packages/web-shared/client/apollosApiLink.js](../packages/web-shared/client/apollosApiLink.js)
+
+In this file, locate the header configuration within the `apollosApiLink` function and uncomment the following line:
+
+```javascript
+// 'x-cache-me-not': 1,
+
+
 ### Options
 
 | data-type      |

--- a/micro-service/README.md
+++ b/micro-service/README.md
@@ -72,7 +72,7 @@ For local development and testing purposes, you might want to enable caching to 
 
 [../packages/web-shared/client/apollosApiLink.js](../packages/web-shared/client/apollosApiLink.js)
 
-In this file, locate the header configuration within the `apollosApiLink` function and uncomment the following line:
+In this file, locate the header configuration within the `apollosApiLink` function and comment the following line:
 
 ```javascript
 // 'x-cache-me-not': 1,

--- a/micro-service/README.md
+++ b/micro-service/README.md
@@ -15,9 +15,9 @@ The JS file used to embed these widgets is hosted on GitHub and picked up by [js
 
 That's it! Your updated version of the apollos-embeds will be available for use.
 
-_⚠️  React needs to be imported in every file it is used, otherwise the js build file will error when you embed it in your website._
+_⚠️ React needs to be imported in every file it is used, otherwise the js build file will error when you embed it in your website._
 
-***
+---
 
 # Using Embeds in Webflow
 
@@ -25,6 +25,7 @@ _⚠️  React needs to be imported in every file it is used, otherwise the js b
 
 Copy the following script tags into your Webflow website. In your Dashboard, you should see the tab 'Custom Code'. Scroll to the bottom and paste the following script tags in the Footer Code block:
 html
+
 ```
 <link href="https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds@0.0.7/widget/index.css" rel="stylesheet"/>
 <script src="https://cdn.jsdelivr.net/npm/@apollosproject/apollos-embeds@0.0.7/widget/index.js"></script>
@@ -45,6 +46,7 @@ Add the class `apollos-widget` to both of those divs. This is necessary for the 
 <img width="935" alt="image" src="https://user-images.githubusercontent.com/2528817/231847323-53430bca-f2fd-4d2c-b7ee-90948fb694b5.png">
 
 ## 4. Adding Custom Attributes:
+
 To control which embed shows up in which div and what church content is displayed, we use 'data-attributes' or 'Custom attributes' in Webflow.
 
 For the 'Auth' embed, add `data-type="Auth"` and `data-church=[INSERT_CHURCH_SLUG_HERE]` as custom attributes. Here's an example for Bayside:
@@ -63,7 +65,6 @@ For the 'FeatureFeed' embed, which displays the church's content, add `data-type
 
 <img width="928" alt="image" src="https://user-images.githubusercontent.com/2528817/231847773-9698dc62-3ca8-4814-ad33-63204fb5f625.png">
 
-
 _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique identifier, or 'slug'._
 
 ### Enabling Caching for Local Frustration
@@ -76,50 +77,47 @@ In this file, locate the header configuration within the `apollosApiLink` functi
 
 ```javascript
 'x-cache-me-not': 1,
-
+```
 
 ### Options
 
-| data-type      |
-|----------------|
-| Auth           |
-| FeatureFeed    |
+| data-type   |
+| ----------- |
+| Auth        |
+| FeatureFeed |
 
-| data-church               |
-|---------------------------|
-| apollos_demo              | 
-| bayside                   | 
-| cedar_creek               |
-| celebration               |
-| chase_oaks                |
-| christ_fellowship         |
-| city_first                |
-| community_christian       |
-| crossings_community_church|
-| crossroads_kids_club      |
-| crossroads_tv             |
-| default                   |
-| eastview                  |
-| eleven22                  |
-| fairhaven                 |
-| fake                      |
-| fake_dag_church           |
-| fellowship_greenville     |
-| fellowship_nwa            |
-| hope_in_real_life         |
-| king_of_kings             |
-| lcbc                      |
-| liquid_church             |
-| newspring                 |
-| oakcliff                  |
-| real_life                 |
-| river_valley              |
-| try_grace                 |
-| willow_creek              |
-| woodmen                   |
-| ymca_gc                   |
+| data-church                |
+| -------------------------- |
+| apollos_demo               |
+| bayside                    |
+| cedar_creek                |
+| celebration                |
+| chase_oaks                 |
+| christ_fellowship          |
+| city_first                 |
+| community_christian        |
+| crossings_community_church |
+| crossroads_kids_club       |
+| crossroads_tv              |
+| default                    |
+| eastview                   |
+| eleven22                   |
+| fairhaven                  |
+| fake                       |
+| fake_dag_church            |
+| fellowship_greenville      |
+| fellowship_nwa             |
+| hope_in_real_life          |
+| king_of_kings              |
+| lcbc                       |
+| liquid_church              |
+| newspring                  |
+| oakcliff                   |
+| real_life                  |
+| river_valley               |
+| try_grace                  |
+| willow_creek               |
+| woodmen                    |
+| ymca_gc                    |
 
-
-***
-
-
+---

--- a/micro-service/README.md
+++ b/micro-service/README.md
@@ -66,7 +66,7 @@ For the 'FeatureFeed' embed, which displays the church's content, add `data-type
 
 _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique identifier, or 'slug'._
 
-### Disabling Caching for Local Testing
+### Enabling Caching for Local Frustration
 
 For local development and testing purposes, you might want to enable caching to ensure you're not receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
 

--- a/packages/web-shared/client/apollosApiLink.js
+++ b/packages/web-shared/client/apollosApiLink.js
@@ -8,8 +8,7 @@ const apollosApiLink = (church_slug) =>
       headers: {
         ...headers,
         'x-church': church_slug,
-        // Uncomment the following line to disable caching
-        // 'x-cache-me-not': 1,
+        'x-cache-me-not': 1,
       },
     }));
 

--- a/packages/web-shared/client/apollosApiLink.js
+++ b/packages/web-shared/client/apollosApiLink.js
@@ -8,6 +8,8 @@ const apollosApiLink = (church_slug) =>
       headers: {
         ...headers,
         'x-church': church_slug,
+        // Uncomment the following line to disable caching
+        // 'x-cache-me-not': 1,
       },
     }));
 

--- a/web-embeds/README.md
+++ b/web-embeds/README.md
@@ -76,6 +76,18 @@ For the 'FeatureFeed' embed, which displays the church's content, add `data-type
 
 _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique identifier, or 'slug'._
 
+### Disabling Caching for Local Testing
+
+For local development and testing purposes, you might want to disable caching to ensure you're receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
+
+[../packages/web-shared/client/apollosApiLink.js](../packages/web-shared/client/apollosApiLink.js)
+
+In this file, locate the header configuration within the `apollosApiLink` function and uncomment the following line:
+
+```javascript
+// 'x-cache-me-not': 1,
+```
+
 ### Options
 
 | data-type   |
@@ -118,3 +130,4 @@ _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique
 | ymca_gc                    |
 
 ---
+```

--- a/web-embeds/README.md
+++ b/web-embeds/README.md
@@ -130,4 +130,3 @@ In this file, locate the header configuration within the `apollosApiLink` functi
 | ymca_gc                    |
 
 ---
-```

--- a/web-embeds/README.md
+++ b/web-embeds/README.md
@@ -76,16 +76,16 @@ For the 'FeatureFeed' embed, which displays the church's content, add `data-type
 
 _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique identifier, or 'slug'._
 
-### Disabling Caching for Local Testing
+### Enabling Caching for Local Frustration
 
-For local development and testing purposes, you might want to disable caching to ensure you're receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
+For local development and testing purposes, you might want to enable caching to ensure you're not receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
 
 [../packages/web-shared/client/apollosApiLink.js](../packages/web-shared/client/apollosApiLink.js)
 
-In this file, locate the header configuration within the `apollosApiLink` function and uncomment the following line:
+In this file, locate the header configuration within the `apollosApiLink` function and comment the following line:
 
 ```javascript
-// 'x-cache-me-not': 1,
+'x-cache-me-not': 1,
 ```
 
 ### Options


### PR DESCRIPTION
## 🐛 Issue

Sometimes you are making changes in Admin and need to see in Web Embeds
<!-- Link to the issue in basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

## ✏️ Solution

Add documentation for how to disable caching
<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Start Admin and Web Embeds
2. Uncomment the `x-cache-me-not` header
3. Change a content item on Apollos Demo (on Admin) and nav to that same item in web embeds (or micro-service)
4. See the change come through immediately

## 📸 Screenshots

<!--
| Before | After |
| --- | --- |
| _attach image_ | _attach image_ |
| _attach image_ | _attach image_ |
-->
https://github.com/ApollosProject/apollos-embeds/assets/72768221/0d41f7e2-af35-42d4-8f1d-b04e29ee06ec