### PR TITLE
Fix crash when opening / closing event feeds

### DIFF
--- a/packages/web-shared/components/ContentChannel.js
+++ b/packages/web-shared/components/ContentChannel.js
@@ -38,7 +38,7 @@ function ContentChannel(props = {}) {
               title={item.node.title}
               summary={item.node.summary}
               onClick={() => handleActionPress(item)}
-              videoMedia={item.relatedNode?.videos[0]}
+              videoMedia={item.relatedNode?.videos?.[0]}
             />
           );
         })}

--- a/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
@@ -20,7 +20,7 @@ function VerticalCardListFeature(props = {}) {
     if (item.action === 'OPEN_URL') {
       analytics.track('OpenUrl', {
         url: item?.relatedNode?.url,
-      });            
+      });
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 
@@ -97,7 +97,7 @@ function VerticalCardListFeature(props = {}) {
               title={item.title}
               summary={item.summary}
               onClick={() => handleActionPress(item)}
-              videoMedia={item.relatedNode?.videos[0]}
+              videoMedia={item.relatedNode?.videos?.[0]}
             />
           ))}
         </Styled.Container>

--- a/packages/web-shared/components/FeatureFeedList/FeatureFeedListGrid.js
+++ b/packages/web-shared/components/FeatureFeedList/FeatureFeedListGrid.js
@@ -49,7 +49,7 @@ function FeatureFeedListGrid(props = {}) {
             title={item.title}
             summary={item.summary}
             onClick={() => handleActionPress(item)}
-            videoMedia={item.relatedNode?.videos[0]}
+            videoMedia={item.relatedNode?.videos?.[0]}
             channelLabel={item.relatedNode?.parentItem?.title}
           />
         ))}


### PR DESCRIPTION
## 🐛 Issue

Clicking "view app" on an events feed would crash the modal.

## ✏️ Solution

Properly safely check for a `[0]`th video

## 🔬 To Test

In web embeds.

[This link should open](http://localhost:3000/?id=FeatureFeed-69cc8825bbc7612068c77496e3e2d9f48ad2b8906c455d95fdbba65e3b0fe30043d83c63592e2b9827777c0c311f2481db9397d1ae6fb376c2f14202e6d92b630b1aefda88740028cfaf9718c06bd477b2bf6e57d416060a3306d3148fd68544221ea9be28470896a68480bac5ef6a8662258bb83c903a024e75b6c250406df5cbf6d4a6b6744c3d05a2871bfbb59d326f7370d5ead1f716a378ab6e42fbec19e49af41f083726caa621ae4f9c5bc727e06b94904750a543b024d05e0dd8ab251c6168f7add50d215a37d8dd3d470680457999b80308ba7888b017f4715fc891f4eb6b420a6ff03a5fb8a0c32bb6c24c&action=viewall), and not display an error screen.

## 📸 Screenshots

https://github.com/ApollosProject/apollos-embeds/assets/1637694/34ada1fe-a36c-4e8e-8e0b-7688a3cb9a95

