### PR TITLE
Add classnames for View All buttons

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -94,7 +94,8 @@ function HorizontalCardListFeature(props = {}) {
             title="View All"
             variant="link"
             onClick={handlePrimaryActionPress}
-            icon={<CaretRight size={18} weight="bold" />}
+            icon={<CaretRight className="primary-action-icon" size={18} weight="bold" />}
+            className="primary-action-button"
           />
         ) : null}
       </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalMediaListFeature.js
@@ -36,7 +36,7 @@ function HorizontalMediaListFeature(props = {}) {
     if (item.action === 'OPEN_URL') {
       analytics.track('OpenUrl', {
         url: item?.relatedNode?.url,
-      });      
+      });
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 
@@ -93,7 +93,8 @@ function HorizontalMediaListFeature(props = {}) {
             title="View All"
             variant="link"
             onClick={handlePrimaryActionPress}
-            icon={<CaretRight size={18} weight="bold" />}
+            icon={<CaretRight className="primary-action-icon" size={18} weight="bold" />}
+            className="primary-action-button"
           />
         ) : null}
       </Box>

--- a/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/VerticalCardListFeature.js
@@ -20,7 +20,7 @@ function VerticalCardListFeature(props = {}) {
     if (item.action === 'OPEN_URL') {
       analytics.track('OpenUrl', {
         url: item?.relatedNode?.url,
-      });            
+      });
       return window.open(getURLFromType(item.relatedNode), '_blank');
     }
 
@@ -75,6 +75,7 @@ function VerticalCardListFeature(props = {}) {
             variant="link"
             onClick={handlePrimaryActionPress}
             icon={<CaretRight size={18} weight="bold" />}
+            className="primary-action-button"
           />
         ) : null}
       </Box>


### PR DESCRIPTION
## 🐛 Issue

Liquid needs some additional targeting options to safely target "View all" links and the associated icons. 

## ✏️ Solution

Added classNames to the "View All" links

## 🔬 To Test

n/a

## 📸 Screenshots

n/a