### PR TITLE
Improve breadcrumbs

### DIFF
--- a/packages/web-shared/components/FeatureFeedList/FeatureFeedListGrid.js
+++ b/packages/web-shared/components/FeatureFeedList/FeatureFeedListGrid.js
@@ -5,7 +5,11 @@ import { withTheme } from 'styled-components';
 
 import { getURLFromType } from '../../utils';
 import { Box, ContentCard, H3 } from '../../ui-kit';
-import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../providers/BreadcrumbProvider';
+import {
+  add as addBreadcrumb,
+  reset as resetBreadcrumb,
+  useBreadcrumbDispatch,
+} from '../../providers/BreadcrumbProvider';
 
 import { open as openModal, set as setModal, useModal } from '../../providers/ModalProvider';
 
@@ -19,7 +23,7 @@ function FeatureFeedListGrid(props = {}) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item.relatedNode)}`,
-          title: item.relatedNode?.title,
+          title: item.title,
         })
       );
       setSearchParams(`?id=${getURLFromType(item.relatedNode)}`);

--- a/packages/web-shared/components/Searchbar/SearchResults.js
+++ b/packages/web-shared/components/Searchbar/SearchResults.js
@@ -10,7 +10,11 @@ import Feed from '../FeatureFeed';
 import { ResourceCard, Box } from '../../ui-kit';
 
 import { getURLFromType } from '../../utils';
-import { add as addBreadcrumb, useBreadcrumbDispatch } from '../../providers/BreadcrumbProvider';
+import {
+  add as addBreadcrumb,
+  reset as resetBreadcrumb,
+  useBreadcrumbDispatch,
+} from '../../providers/BreadcrumbProvider';
 import { open as openModal, set as setModal, useModal } from '../../providers/ModalProvider';
 import { ClockCounterClockwise, MagnifyingGlass, CaretRight, X } from 'phosphor-react';
 
@@ -139,6 +143,8 @@ const SearchResults = ({ autocompleteState, autocomplete }) => {
   }, [autocompleteState.collections]);
 
   const handleActionPress = (item) => {
+    console.log(item);
+    dispatchBreadcrumb(resetBreadcrumb());
     if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({

--- a/packages/web-shared/components/Searchbar/SearchResults.js
+++ b/packages/web-shared/components/Searchbar/SearchResults.js
@@ -143,7 +143,6 @@ const SearchResults = ({ autocompleteState, autocomplete }) => {
   }, [autocompleteState.collections]);
 
   const handleActionPress = (item) => {
-    console.log(item);
     dispatchBreadcrumb(resetBreadcrumb());
     if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(


### PR DESCRIPTION
## 🐛 Issue

Two issues 
- Event items don't generate breadcrumbs
- Open an item from search adds to the breadcrumbs into infinity ♾️ 

## ✏️ Solution

- Don't dig into the `relatedNode` to use a title, the passed `title` is good enough #49 
- Reset the breadcrumbs when opening a item from search

## 🔬 To Test

From `web-embeds`

1. Tap around in search
  - make sure the breadcrumbs are clearing when searching
  - make sure tapping series children adds to the breadcrumbs as expected
2.Tap around on [this event feed](http://localhost:3000/?id=FeatureFeed-69cc8825bbc7612068c77496e3e2d9f48ad2b8906c455d95fdbba65e3b0fe30043d83c63592e2b9827777c0c311f2481db9397d1ae6fb376c2f14202e6d92b630b1aefda88740028cfaf9718c06bd477b2bf6e57d416060a3306d3148fd68544221ea9be28470896a68480bac5ef6a8662258bb83c903a024e75b6c250406df5cbf6d4a6b6744c3d05a2871bfbb59d326f7370d5ead1f716a378ab6e42fbec19e49af41f083726caa621ae4f9c5bc727e06b94904750a543b024d05e0dd8ab251c6168f7add50d215a37d8dd3d470680457999b80308ba7888b017f4715fc891f4eb6b420a6ff03a5fb8a0c32bb6c24c&action=viewall)
 - Ensure breadcrumbs work as expected  

## 📸 Screenshots
![CleanShot 2024-02-23 at 09 17 09@2x](https://github.com/ApollosProject/apollos-embeds/assets/1637694/e2be4b86-5b4e-43a4-b58e-f2925ce0fa63)
![CleanShot 2024-02-23 at 09 17 03@2x](https://github.com/ApollosProject/apollos-embeds/assets/1637694/5b350e18-65da-4d3a-958c-d8b4ca173296)


https://github.com/ApollosProject/apollos-embeds/assets/1637694/a7eb4cb6-162f-41e9-ac19-2df2ca663068


