### PR TITLE
feat: Chips should open in a new tab

### DIFF
--- a/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/ChipListFeature.js
@@ -1,14 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { systemPropTypes, Box, PhospherIcon } from '../../../ui-kit';
 import Styled from './ChipListFeature.styles';
 
-function ChipListFeature(props = {}) {
-  if (props?.feature?.chips?.length === 0 || !props?.feature?.chips) {
+function ChipListFeature({ feature }) {
+  if (feature?.chips?.length === 0 || !feature?.chips) {
     return null;
   }
 
-  const title = props.feature.title || props.feature.subtitle;
+  const title = feature.title || feature.subtitle;
+  const origin = window.location.origin;
 
   return (
     <Box className="chip-list-feature">
@@ -18,9 +20,11 @@ function ChipListFeature(props = {}) {
         </Box>
       ) : null}
       <Styled.List>
-        {props.feature?.chips?.map(({ title, iconName, relatedNode }, index) => {
+        {feature?.chips?.map(({ title, iconName, relatedNode }, index) => {
+          const linkOrigin = new URL(relatedNode.url).origin;
+          const external = linkOrigin !== origin;
           return (
-            <Styled.Chip href={relatedNode.url} key={index}>
+            <Styled.Chip href={relatedNode.url} key={index} target={external ? '_blank' : '_self'}>
               <PhospherIcon
                 name={iconName || 'arrow-up-right'}
                 size={20}
@@ -38,6 +42,19 @@ function ChipListFeature(props = {}) {
 
 ChipListFeature.propTypes = {
   ...systemPropTypes,
+  feature: PropTypes.shape({
+    title: PropTypes.string,
+    subtitle: PropTypes.string,
+    chips: PropTypes.arrayOf(
+      PropTypes.shape({
+        title: PropTypes.string,
+        iconName: PropTypes.string,
+        relatedNode: PropTypes.shape({
+          url: PropTypes.string,
+        }),
+      })
+    ),
+  }),
 };
 
 export default ChipListFeature;


### PR DESCRIPTION
## 🐛 Issue

[Chips to external links should open in a new tab](https://3.basecamp.com/3926363/buckets/32694519/card_tables/cards/7118163262)

## ✏️ Solution

If a link is pointed at a different origin, open it in a new tab. 

## 🔬 To Test

1. [Visit this item](https://apollos-web-embeds-git-chips-external-apollos-embeds.vercel.app/?id=the-way-of-worship-TWVkaWFDb250ZW50SXRlbS04OGMyNzkwMC03YWNkLTQ2MmEtYTc0Yi0zNTI1OGJhYTA4NWI%3D)
2. Tapping one of the chips should open a new tab. 

## 📸 Screenshots


https://github.com/ApollosProject/apollos-embeds/assets/1637694/85a86f27-4d58-4fb9-966f-730f9ab9444f

