### PR TITLE
tweak: Change default search limit to 8

### DIFF
--- a/packages/web-shared/components/Searchbar/Autocomplete.js
+++ b/packages/web-shared/components/Searchbar/Autocomplete.js
@@ -180,7 +180,7 @@ export default function Autocomplete({
                     indexName: `ContentItem_${searchState.church}`,
                     query,
                     params: {
-                      hitsPerPage: 4,
+                      hitsPerPage: 8,
                       clickAnalytics: true,
                       // highlightPreTag: '<mark>',
                       // highlightPostTag: '</mark>',


### PR DESCRIPTION
## 🐛 Issue

Liquid wants to show 8 items in search

<!--Github issue this PR will close. Remove if not valid.-->
Closes #

## ✏️ Solution

Show eight search results

## 🔬 To Test


1. [Visit the web embed](https://apollos-web-embeds-git-default-search-lim-164478-apollos-embeds.vercel.app/)
2. Search a term (like marriage) 

## 📸 Screenshots

![CleanShot 2024-02-27 at 10 58 08@2x](https://github.com/ApollosProject/apollos-embeds/assets/1637694/f2597edd-098d-4d97-adc0-325e44cc81be)
