### PR TITLE
fix: when clicking events from a link the breadcrumbs are broken

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -8,7 +8,11 @@ import { getURLFromType } from '../utils';
 import { format, parseISO } from 'date-fns';
 import FeatureFeed from './FeatureFeed';
 import FeatureFeedComponentMap from './FeatureFeed/FeatureFeedComponentMap';
-import { add as addBreadcrumb, useBreadcrumbDispatch } from '../providers/BreadcrumbProvider';
+import {
+  add as addBreadcrumb,
+  remove as removeBreadcrumb,
+  useBreadcrumbDispatch,
+} from '../providers/BreadcrumbProvider';
 import { set as setModal, useModal } from '../providers/ModalProvider';
 
 import {
@@ -169,6 +173,7 @@ function ContentSingle(props = {}) {
         )}`
       : null;
   const handleActionPress = (item) => {
+    dispatchBreadcrumb(removeBreadcrumb());
     if (searchParams.get('id') !== getURLFromType(item)) {
       dispatchBreadcrumb(
         addBreadcrumb({

--- a/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HorizontalCardListFeature.js
@@ -44,7 +44,7 @@ function HorizontalCardListFeature(props = {}) {
       dispatchBreadcrumb(
         addBreadcrumb({
           url: `?id=${getURLFromType(item.relatedNode)}`,
-          title: item.relatedNode?.title,
+          title: item.relatedNode?.title || item?.title,
         })
       );
       setSearchParams(`?id=${getURLFromType(item.relatedNode)}`);


### PR DESCRIPTION
## 🐛 Issue

When clicking events from a link the breadcrumbs are broken https://github.com/ApollosProject/apollos-embeds/issues/181

## ✏️ Solution

breadcrumb issues - remove last item from  breadcrumb on ContentSingle
title issue - add missing title param


## 🔬 To Test

1. Navigate to series item 
2. Keep selecting single content items of that series

## 📸 Screenshots

https://github.com/ApollosProject/apollos-embeds/assets/28708210/b9dca95c-6421-47b7-80fc-86b2f20f9cc3

