### PR TITLE
fix: spacing under event title

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -264,6 +264,7 @@ function ContentSingle(props = {}) {
                 flexDirection="row"
                 justifyContent="space-between"
                 alignItems="center"
+                mb="base"
               >
                 {title ? <Title>{title}</Title> : null}
                 {/* Button moves below on mobile views */}


### PR DESCRIPTION
## 🐛 Issue

Spacing under event title https://github.com/ApollosProject/apollos-embeds/issues/180

## ✏️ Solution

fix title spacing

## 🔬 To Test

1. Navigate to event content
2. Check spacing between title and event data
3. Sample event data

`<div
      data-type="FeatureFeed"
      data-church="liquid_church"
      data-feature-feed="FeatureFeed:e5d913ee-0f28-45a3-8f71-f5ce2ae6cb3b"
      data-placeholder="What are you looking for?"
      data-modal="true"
      class="apollos-widget"
    ></div>`

## 📸 Screenshots

![Screenshot 2024-03-05 at 8 58 51 PM](https://github.com/ApollosProject/apollos-embeds/assets/28708210/fe3cab2e-208f-441c-826a-6bd0d5ff98b7)
