### PR TITLE
fix: too much space between child vertical cards

### DIFF
--- a/packages/web-shared/components/ContentSeriesSingle.js
+++ b/packages/web-shared/components/ContentSeriesSingle.js
@@ -212,7 +212,7 @@ function ContentSeriesSingle(props = {}) {
               <H3 mb="xs">{props.feature?.title}</H3>
               <Box
                 display="grid"
-                gridGap="100px 30px"
+                gridGap="70px 30px"
                 gridTemplateColumns={{
                   _: 'repeat(1, minmax(0, 1fr));',
                   md: 'repeat(2, minmax(0, 1fr));',


### PR DESCRIPTION
## 🐛 Issue

too much space between child vertical cards https://github.com/ApollosProject/apollos-embeds/issues/179

## ✏️ Solution

fix gap in child series

## 🔬 To Test

1. go to link -> http://localhost:3000/watch?id=the-way-Q29udGVudFNlcmllc0NvbnRlbnRJdGVtLTdmMGMzOTA0LTc1MDQtNGUwYi05MzFhLWFjNTliNDA3NDRhYQ%3D%3D
2. Check gap between child items in series

## 📸 Screenshots

![Screenshot 2024-03-06 at 6 13 45 PM](https://github.com/ApollosProject/apollos-embeds/assets/28708210/dc4e45fc-e1f7-4436-a9c8-8253f5f12259)
