### PR TITLE
skips feature feed query if no ID

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -103,6 +103,7 @@ function ContentSingle(props = {}) {
     variables: {
       itemId: feedId,
     },
+    skip: !feedId,
   });
 
   const invalidPage = !props.loading && !props.data;


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
We're making LOTS of invalid requests to the server. This is causing a lot of unnecessary load on the server.

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

Skip making requests to the server if there's no feed ID

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

Not really sure...

## 📸 Screenshots

<!--
| Before | After |
| --- | --- |
| _attach image_ | _attach image_ |
| _attach image_ | _attach image_ |
-->

<img width="1812" alt="Screenshot 2024-03-21 at 4 58 52 PM" src="https://github.com/ApollosProject/apollos-embeds/assets/2659478/bc59b0b8-dd85-435e-88f9-e633213c2c6b">

