### PR TITLE
feat: Add canonical url

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -190,12 +190,16 @@ function ContentSingle(props = {}) {
     }
   };
 
+  // Try and convince Google that this is the canonical URL
+  const canonicalUrl = `${window.location.origin}?id=${searchParams.get('id')}`;
+
   return (
     <>
       {/* TODO: Max width set to 750px due to low resolution pictures. Can be increased as higher quality images are used */}
       <Helmet>
         {/* Standard metadata tags */}
         <title>{title}</title>
+        <link rel="canonical" href={canonicalUrl} />
         <meta name="description" content={summary} />
         <meta name="image" content={coverImage?.sources[0]?.uri} />
         {/* End standard metadata tags */}


### PR DESCRIPTION
## 🐛 Issue

I believe Google is flagging many liquid pages as duplicates

## ✏️ Solution

Use the canonical URL prop to convince google that certain pages are the same. 

## 🔬 To Test



1. Start the web embeds test server
2. Visit a content item
3. Look for the canonical link tag,. 

## 📸 Screenshots

![CleanShot 2024-03-28 at 13 46 10@2x](https://github.com/ApollosProject/apollos-embeds/assets/1637694/c4aeee60-0f4e-42ed-99f8-e1536d5fb749)
