### PR TITLE
Add commenting to web

### DIFF
--- a/micro-service/src/index.css
+++ b/micro-service/src/index.css
@@ -15,8 +15,12 @@ html {
 html,
 body {
   height: 100%;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  background-color: #f8f8fa;
+}
+
+* {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu,
+    Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
 img {
@@ -36,4 +40,6 @@ input:focus-visible {
   outline: none;
 }
 
-::selection { background: rgba(110,197,184, 0.62); /* base.tertiary */ }
+::selection {
+  background: rgba(110, 197, 184, 0.62); /* base.tertiary */
+}

--- a/packages/web-shared/components/Comments/AddComment.js
+++ b/packages/web-shared/components/Comments/AddComment.js
@@ -1,0 +1,136 @@
+import { gql, useMutation } from '@apollo/client';
+import { useState, useRef, useEffect } from 'react';
+import { Spinner, PaperPlaneTilt } from '@phosphor-icons/react';
+import styled, { withTheme } from 'styled-components';
+import { themeGet } from '@styled-system/theme-get';
+import Color from 'color';
+import { TypeStyles } from '../../ui-kit/Typography';
+import { system } from '../../ui-kit/_lib/system';
+import { Avatar, Box, Button, H5 } from '../../ui-kit';
+import { useCurrentUser } from '../../hooks';
+
+const ADD_COMMENT = gql`
+  mutation addComment($parentId: ID!, $text: String!) {
+    addComment(parentId: $parentId, text: $text) {
+      id
+      isLiked
+      text
+      person {
+        id
+        firstName
+        lastName
+        photo {
+          uri
+        }
+      }
+    }
+  }
+`;
+
+const TextArea = withTheme(styled.textarea`
+  ${TypeStyles.BodyText}
+  padding: 0;
+  padding-right: 8px;
+  outline: none;
+  flex-grow: 1;
+  max-height: 200px;
+  transition: all ${themeGet('timing.xl')} ease-out;
+  placeholder-text-color: ${({ theme }) => Color(theme.colors.text.secondary).alpha(0)};
+  caret-color: ${themeGet('colors.base.primary')};
+  border: none;
+  resize: none;
+
+  ${system};
+`);
+
+const AddComment = ({ parent, onAdd }) => {
+  const { currentUser } = useCurrentUser();
+  const [comment, setComment] = useState('');
+  const textAreaRef = useRef(null);
+
+  const [addComment, { data, loading, error }] = useMutation(ADD_COMMENT, {
+    update(cache, { data: { addComment } }) {
+      cache.modify({
+        id: cache.identify(parent),
+        fields: {
+          comments(existingComments = []) {
+            const newCommentRef = cache.writeFragment({
+              data: addComment,
+              fragment: gql`
+                fragment NewComment on Comment {
+                  id
+                  isLiked
+                  text
+                  person {
+                    id
+                    firstName
+                    lastName
+                    photo {
+                      uri
+                    }
+                  }
+                }
+              `,
+            });
+            return [...existingComments, newCommentRef];
+          },
+        },
+      });
+    },
+  });
+
+  const handleInputChange = (e) => {
+    setComment(e.target.value);
+  };
+
+  const handleAddComment = async () => {
+    await addComment({ variables: { parentId: parent.id, text: comment } });
+    setComment('');
+    textAreaRef.current.style.height = 'auto';
+    if (onAdd) onAdd(data);
+  };
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      // We need to reset the height momentarily to get the correct scrollHeight for the textarea
+      textAreaRef.current.style.height = '0px';
+      const scrollHeight = textAreaRef.current.scrollHeight;
+
+      // We then set the height directly, outside of the render loop
+      // Trying to set this with state or a ref will product an incorrect value.
+      textAreaRef.current.style.height = scrollHeight + 'px';
+    }
+  }, [textAreaRef, comment]);
+
+  return (
+    <Box p="xs" borderTop="1px solid" borderColor="text.quaternary">
+      <Box display="flex" flexDirection="row" alignItems="center" gridGap={8} pb="xs">
+        <Avatar
+          src={currentUser?.profile?.photo?.uri}
+          firstName={currentUser?.profile?.firstName}
+          lastName={currentUser?.profile?.lastName}
+          width={48}
+        />
+        <H5>
+          {currentUser?.profile.firstName} {currentUser?.profile?.lastName}
+        </H5>
+      </Box>
+      <Box display="flex" flexDirection="row" justifyContent="space-between" alignItems="center">
+        <TextArea
+          value={comment}
+          onChange={handleInputChange}
+          placeholder="Add a response"
+          ref={textAreaRef}
+        />
+        <Button
+          disabled={!comment}
+          onClick={comment ? handleAddComment : undefined}
+          icon={loading ? <Spinner /> : <PaperPlaneTilt weight="fill" />}
+          padding={6}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default AddComment;

--- a/packages/web-shared/components/Comments/Comment.js
+++ b/packages/web-shared/components/Comments/Comment.js
@@ -1,0 +1,29 @@
+import { Box, H5, Avatar } from '../../ui-kit';
+
+// turn line breaks into <br> tags and strip out any other html
+function formatText(text) {
+  return text.split('\n').map((line, i) => (
+    <span key={i}>
+      {line}
+      <br />
+    </span>
+  ));
+}
+const Comment = ({ text, person }) => (
+  <Box p="xs" borderBottom="1px solid" borderColor="text.quaternary">
+    <Box display="flex" flexDirection="row" alignItems="center" gridGap={8} pb="xs">
+      <Avatar
+        src={person?.photo?.uri}
+        firstName={person.firstName}
+        lastName={person.lastName}
+        width={48}
+      />
+      <H5>
+        {person.firstName} {person.lastName}
+      </H5>
+    </Box>
+    <p>{formatText(text)}</p>
+  </Box>
+);
+
+export default Comment;

--- a/packages/web-shared/components/Comments/Comments.js
+++ b/packages/web-shared/components/Comments/Comments.js
@@ -1,0 +1,94 @@
+import { useRef, useState } from 'react';
+import { Box, H4, Button } from '../../ui-kit';
+import { X, ArrowRight, ChatsCircle } from '@phosphor-icons/react';
+import { useCurrentUser } from '../../hooks';
+import { AuthManager } from '../../components';
+
+import { useAuth } from '../../providers/AuthProvider';
+import authSteps from '../Auth/authSteps';
+
+import Comment from './Comment';
+import AddComment from './AddComment';
+
+export const SIDEBAR_WITH = 400;
+
+const Comments = ({ visible, parent, comments, onClose }) => {
+  const { currentUser } = useCurrentUser();
+  const [state] = useAuth();
+  const scrollRef = useRef(null);
+  const [showAuth, setShowAuth] = useState(false);
+
+  const scrollToBottom = () => {
+    requestAnimationFrame(() => scrollRef.current.scrollIntoView(false));
+  };
+
+  return (
+    <Box
+      width={{ md: SIDEBAR_WITH }}
+      position="fixed"
+      top={58}
+      right={0}
+      bottom={0}
+      left={{ _: 0, md: 'auto' }}
+      backgroundColor="fill.paper"
+      borderLeftStyle={{ _: 'none', md: 'solid' }}
+      borderLeftWidth={{ _: '0', md: '1px' }}
+      borderLeftColor="text.quaternary"
+      display="flex"
+      flexDirection="column"
+    >
+      <Box
+        p="xs"
+        borderBottom="1px solid"
+        borderColor="text.quaternary"
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <H4>Responses</H4>
+        <Box cursor="pointer" display="flex" color="text.secondary" onClick={onClose}>
+          <X />
+        </Box>
+      </Box>
+      {currentUser ? (
+        <>
+          <Box style={{ overflowY: 'scroll' }}>
+            {comments.map((comment) => (
+              <Comment key={comment.id} {...comment} />
+            ))}
+            <div ref={scrollRef} style={{ height: 1 }} />
+          </Box>
+          <AddComment parent={parent} onAdd={scrollToBottom} />
+        </>
+      ) : (
+        <Box
+          p="md"
+          flexGrow="1"
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Box color="base.primary">
+            <ChatsCircle size={90} weight="fill" />
+          </Box>
+          <H4>Join the conversation</H4>
+          <Button
+            variant="secondary"
+            title="Sign up or Login"
+            onClick={() => setShowAuth(true)}
+            color="base.primary"
+            icon={<ArrowRight size={24} />}
+            mt="base"
+          />
+        </Box>
+      )}
+      {showAuth && state.step !== authSteps.Success ? (
+        <AuthManager onClose={() => setShowAuth(false)} />
+      ) : null}
+    </Box>
+  );
+};
+
+export default Comments;

--- a/packages/web-shared/components/Comments/index.js
+++ b/packages/web-shared/components/Comments/index.js
@@ -1,0 +1,5 @@
+import Comments, { SIDEBAR_WITH } from './Comments';
+
+export { SIDEBAR_WITH };
+
+export default Comments;

--- a/packages/web-shared/fragments/fragments.js
+++ b/packages/web-shared/fragments/fragments.js
@@ -69,6 +69,20 @@ const CONTENT_SINGLE_FRAGMENT = gql`
   fragment ContentSingleFragment on ContentItem {
     title
     htmlContent
+    commentsEnabled
+    comments {
+      id
+      isLiked
+      text
+      person {
+        id
+        firstName
+        lastName
+        photo {
+          uri
+        }
+      }
+    }
     coverImage {
       sources {
         uri

--- a/packages/web-shared/ui-kit/Avatar/Avatar.js
+++ b/packages/web-shared/ui-kit/Avatar/Avatar.js
@@ -1,20 +1,40 @@
 import React from 'react';
 import { withTheme } from 'styled-components';
+import { User } from '@phosphor-icons/react';
 
 import { Box, systemPropTypes } from '../../ui-kit';
 
 function Avatar(props = {}) {
   return (
     <Box
-      as="img"
+      as={props.src ? 'img' : undefined}
+      backgroundColor="fill.system"
       position="relative"
       borderRadius="round"
       overflow="hidden"
       boxShadow="medium"
-      height="auto"
       width="60px"
+      height={props.width || '60px'}
       {...props}
-    />
+    >
+      {!props.src ? (
+        props.firstName && props.lastName ? (
+          <Box
+            height="100%"
+            width="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            color="text.secondary"
+          >
+            {props.firstName[0]}
+            {props.lastName[0]}
+          </Box>
+        ) : (
+          <User size={16} weight="bold" />
+        )
+      ) : null}
+    </Box>
   );
 }
 

--- a/packages/web-shared/ui-kit/Button/Button.js
+++ b/packages/web-shared/ui-kit/Button/Button.js
@@ -20,10 +20,12 @@ const Button = ({
       {...props}
     >
       <Styled.Content flexDirection={props.flexDirection}>
-        <Styled.Title disabled={props.disabled} size={size}>
-          {props.title}
-        </Styled.Title>
-        <Styled.Icon>{props?.icon}</Styled.Icon>
+        {props.title ? (
+          <Styled.Title disabled={props.disabled} size={size}>
+            {props.title}
+          </Styled.Title>
+        ) : null}
+        {props.icon ? <Styled.Icon>{props?.icon}</Styled.Icon> : null}
       </Styled.Content>
     </Styled.Button>
   );

--- a/packages/web-shared/ui-kit/Button/Button.styles.js
+++ b/packages/web-shared/ui-kit/Button/Button.styles.js
@@ -130,7 +130,7 @@ const buttonWidth = ({ width }) => {
   `;
 };
 
-const buttonColorState = ({ theme, disabled, focused, hovered }) => {
+const buttonColorState = ({ theme, variant, disabled, focused, hovered }) => {
   if (disabled) {
     return css`
       color: ${theme.colors.text.secondary};
@@ -173,7 +173,7 @@ const buttonColorTypeProp = ({ variant }) => {
 
     case 'secondary':
       return css`
-        color: ${themeGet('colors.text.action')};
+        color: ${themeGet('colors.text.secondary')};
       `;
     case 'link':
       return css`

--- a/web-embeds/public/index.html
+++ b/web-embeds/public/index.html
@@ -1,18 +1,17 @@
 <!doctype html>
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-  <!--
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -21,29 +20,29 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <style>
-    body {
-      font-family:
-        "Inter",
-        -apple-system,
-        BlinkMacSystemFont,
-        Segoe UI,
-        Roboto,
-        Oxygen,
-        Ubuntu,
-        Cantarell,
-        Fira Sans,
-        Droid Sans,
-        Helvetica Neue,
-        sans-serif;
-    }
-  </style>
-</head>
+    <style>
+      * {
+        font-family:
+          "Inter",
+          -apple-system,
+          BlinkMacSystemFont,
+          Segoe UI,
+          Roboto,
+          Oxygen,
+          Ubuntu,
+          Cantarell,
+          Fira Sans,
+          Droid Sans,
+          Helvetica Neue,
+          sans-serif;
+      }
+    </style>
+  </head>
 
-<body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <!-- This is an example of how to use the apollos widgets -->
-  <!-- <div
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!-- This is an example of how to use the apollos widgets -->
+    <!-- <div
       data-church="cedar_creek"
       data-type="FeatureFeed"
       data-feature-feed="FeatureFeed:5aae43e6-3526-4cd2-8dfe-771d2ce8a333"
@@ -53,14 +52,24 @@
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
 
-  <div data-type="FeatureFeed" data-church="liquid_church"
-    data-feature-feed="FeatureFeed:04160599-4edf-4824-98c5-02c1a8854c48" data-placeholder="What are you looking for?"
-    data-modal="true" class="apollos-widget"></div>
+    <div
+      data-type="FeatureFeed"
+      data-church="liquid_church"
+      data-feature-feed="FeatureFeed:04160599-4edf-4824-98c5-02c1a8854c48"
+      data-placeholder="What are you looking for?"
+      data-modal="true"
+      class="apollos-widget"
+    ></div>
 
-  <div data-type="FeatureFeed" data-church="liquid_church"
-    data-feature-feed="FeatureFeed:7ff30e63-caa8-4015-bc00-73633e857b2f" data-modal="true" class="apollos-widget"
-    data-empty-placeholder-text="No jobs today!"></div>
-  <!-- 
+    <div
+      data-type="FeatureFeed"
+      data-church="liquid_church"
+      data-feature-feed="FeatureFeed:7ff30e63-caa8-4015-bc00-73633e857b2f"
+      data-modal="true"
+      class="apollos-widget"
+      data-empty-placeholder-text="No jobs today!"
+    ></div>
+    <!-- 
     <div
       data-church="cedar_creek"
       data-type="Search"
@@ -69,15 +78,23 @@
       class="apollos-widget"
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
-  <div data-church="liquid_church" data-type="Auth" data-modal="true" class="apollos-widget"
-    style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
-    data-search-feed="FeatureFeed:07e1050d-a6c4-4b46-a2a0-12d8fbf1df3c"></div>
-  <div data-type="FeatureFeed" data-church="liquid_church"
-    data-feature-feed="FeatureFeed:d3912726-487b-4635-9cec-99ed84a21209" data-modal="true" class="apollos-widget">
-  </div>
+    <div
+      data-church="liquid_church"
+      data-type="Auth"
+      data-modal="true"
+      class="apollos-widget"
+      style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
+      data-search-feed="FeatureFeed:07e1050d-a6c4-4b46-a2a0-12d8fbf1df3c"
+    ></div>
+    <div
+      data-type="FeatureFeed"
+      data-church="liquid_church"
+      data-feature-feed="FeatureFeed:d3912726-487b-4635-9cec-99ed84a21209"
+      data-modal="true"
+      class="apollos-widget"
+    ></div>
 
-
-  <!--
+    <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -87,6 +104,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-</body>
-
+  </body>
 </html>

--- a/web-embeds/src/index.css
+++ b/web-embeds/src/index.css
@@ -19,6 +19,23 @@
     sans-serif;
 }
 
+.apollos-widget * {
+  font-family:
+    inherit,
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    Segoe UI,
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    Fira Sans,
+    Droid Sans,
+    Helvetica Neue,
+    sans-serif;
+}
+
 .apollos-widget ul {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

There's no commenting on web

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

Add commenting on web! Built with quick and easy components, tried to handle most states/things but within constraints of current code standards.

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Open a content item with discussions
2. Tap new discussion button
3. Add comments
4. Do the same on a content item w/o discussions
💸

## 📸 Screenshots

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/Iqv8SYVwCDX0dUbjBiDz/8d4c27ed-22ac-4780-bbf5-78537882b0df.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Iqv8SYVwCDX0dUbjBiDz/8d4c27ed-22ac-4780-bbf5-78537882b0df.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Iqv8SYVwCDX0dUbjBiDz/8d4c27ed-22ac-4780-bbf5-78537882b0df.mp4">demo comments.mp4</video>

