### PR TITLE
Fixed sharing content changes the formatting #216

### DIFF
--- a/packages/web-shared/ui-kit/Longform/Longform.styles.js
+++ b/packages/web-shared/ui-kit/Longform/Longform.styles.js
@@ -3,6 +3,7 @@ import { themeGet } from '@styled-system/theme-get';
 
 import { system } from '../_lib/system';
 import { TypeStyles } from '../Typography';
+import { utils } from "../index";
 
 const Longform = styled.div`
   ${TypeStyles.BodyText};
@@ -17,6 +18,7 @@ const Longform = styled.div`
   h1 {
     margin-bottom: ${themeGet('space.xl')};
     margin-top: ${themeGet('space.xl')};
+    line-height: ${utils.rem('32px')};
   }
   h2 {
     margin-bottom: ${themeGet('space.l')};


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

#216 

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

Fixed Line Height

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Add a HTML content page with Long text H1 tags. with the auto wrap line height should be fine.
2.

## 📸 Screenshots
<img width="295" alt="Screenshot 2024-05-03 at 18 53 00" src="https://github.com/ApollosProject/apollos-embeds/assets/138706838/a9c93f95-c6df-4b1f-8f4c-77c397dac482">
<img width="719" alt="Screenshot 2024-05-03 at 19 23 23" src="https://github.com/ApollosProject/apollos-embeds/assets/138706838/b892c583-9941-41fa-8543-748543776ed1">




<!--
| Before | After |
| --- | --- |
| _attach image_ | _attach image_ |
| _attach image_ | _attach image_ |
-->
