### PR TITLE
fix: search is busted

### DIFF
--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -33,6 +33,7 @@ const Searchbar = (props = {}) => {
   const userExist = !!currentUser;
   const firstName = currentUser?.profile?.firstName || '';
   const [isMobile, setIsMobile] = useState(false);
+  const [scrollPosition, setScrollPosition] = useState(0);
 
   const textWelcome =
     firstName === '' ? <strong>Hey!&nbsp;</strong> : <strong>Hey {firstName}!&nbsp; </strong>;
@@ -93,6 +94,27 @@ const Searchbar = (props = {}) => {
       setShowTextPrompt(false);
     }
   }, [autocompleteState.isOpen]);
+
+  useEffect(() => {
+    if (isMobile && autocompleteState.isOpen) {
+      // Save the current scroll position
+      setScrollPosition(window.scrollY);
+
+      // Set body to fixed position to prevent scrolling
+      document.body.style.position = 'fixed';
+    } else {
+      // Restore body to normal position
+      document.body.style.position = '';
+
+      // Restore the scroll position
+      window.scrollTo(0, scrollPosition);
+    }
+
+    // Clean up the effect when the component unmounts
+    return () => {
+      document.body.style.position = '';
+    };
+  }, [autocompleteState.isOpen, scrollPosition, isMobile]);
 
   const handleGetAutocompleteInstance = (instance) => {
     setAutocompleteInstance(instance);


### PR DESCRIPTION
## 🐛 Issue

Background page scroll under search result
Closes https://github.com/ApollosProject/apollos-embeds/issues/219

## ✏️ Solution

fix scroll issue in mobile search

## 🔬 To Test

1. Open web embeds search in mobile browser
2. Check background page scroll under search result

## 📸 Screenshots


https://github.com/ApollosProject/apollos-embeds/assets/28708210/c45bc555-a784-4f78-9713-474f03b30995

