### PR TITLE
fix: search is busted reopen

### DIFF
--- a/packages/web-shared/components/Searchbar/Search.styles.js
+++ b/packages/web-shared/components/Searchbar/Search.styles.js
@@ -35,7 +35,7 @@ const showPanel = ({ dropdown }) => {
         padding-bottom: 15px;
       }
       @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
-        height: 100vh;
+        max-height: 80vh;
         z-index: 1000;
         padding-bottom: 15px;
       }


### PR DESCRIPTION

## 🐛 Issue

Search is busted
Closes https://github.com/ApollosProject/apollos-embeds/issues/219

## ✏️ Solution

set panel height 80% from vh to make scrollable 

## 🔬 To Test

1. Open web embeds search in mobile browser

## 📸 Screenshots


https://github.com/ApollosProject/apollos-embeds/assets/28708210/cb62172f-7e2e-43a3-a4ef-c1066875bfe2

