### PR TITLE
Fix basic aria states

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -266,7 +266,7 @@ function ContentSingle(props = {}) {
             </Box>
           ) : null}
 
-          <Box mb="l">
+          <Box mb="l" role="main">
             <Box mb="s" borderBottom="1px solid" borderColor="text.quaternary">
               {/* Title */}
               <Box
@@ -392,6 +392,13 @@ function ContentSingle(props = {}) {
                   borderRadius="l"
                   cursor="pointer"
                   onClick={() => handleActionPress(parentItem)}
+                  role="link"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleActionPress(parentItem);
+                    }
+                  }}
                 >
                   {/* Image */}
                   <Box

--- a/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
+++ b/packages/web-shared/components/FeatureFeed/Features/HeroListFeature.js
@@ -59,6 +59,12 @@ function HeroListFeature(props = {}) {
         borderRadius="l"
         cursor="pointer"
         onClick={handleHeroCardPress}
+        tabIndex="0"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            handleHeroCardPress();
+          }
+        }}
       >
         {/* Image */}
         <Box

--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import { useCurrentChurch } from '../../hooks';
 import { systemPropTypes } from '../../ui-kit/_lib/system';
 import Styled from './Modal.styles';
@@ -28,6 +28,7 @@ const Modal = (props = {}) => {
   const [state, dispatch] = useModal();
 
   const ref = useRef();
+  const imageRef = useRef();
   const { id, navigate } = useNavigation();
 
   useEffect(() => {
@@ -59,12 +60,20 @@ const Modal = (props = {}) => {
     }
   }, [state.content]);
 
+  // When the modal is open, focus on the modal
+  // This is for accessibility
+  useEffect(() => {
+    if (ref.current && state.isOpen) {
+      ref.current.focus();
+    }
+  }, [ref.current, state.isOpen]);
+
   return (
     <Box>
       <Styled.Modal show={state.isOpen}>
         {state.content ? (
           <>
-            <Styled.ModalContainer ref={ref}>
+            <Styled.ModalContainer ref={ref} role="dialog" tabIndex={-1} aria-dialog={true}>
               <Box
                 width="100%"
                 display="flex"
@@ -82,6 +91,7 @@ const Modal = (props = {}) => {
                   p="s"
                   size="60px"
                   borderRadius="xl"
+                  ref={imageRef}
                 />
               </Box>
               <Box
@@ -95,7 +105,16 @@ const Modal = (props = {}) => {
                 top="xs"
                 right="xs"
               >
-                <Styled.Icon onClick={handleCloseModal} ml={{ _: 'auto', sm: '0' }}>
+                <Styled.Icon
+                  onClick={handleCloseModal}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleCloseModal();
+                    }
+                  }}
+                  ml={{ _: 'auto', sm: '0' }}
+                  tabIndex={1}
+                >
                   <X size={16} weight="bold" />
                 </Styled.Icon>
               </Box>

--- a/packages/web-shared/components/Wordmark/Wordmark.js
+++ b/packages/web-shared/components/Wordmark/Wordmark.js
@@ -5,10 +5,10 @@ import Styled from './Wordmark.styles';
 
 import { systemPropTypes } from '../../ui-kit';
 
-function Wordmark({ size, source, href }) {
+function Wordmark({ size, source, href, ref }) {
   if (href) {
     return (
-      <a href={href}>
+      <a href={href} ref={ref}>
         <Styled.WrappedImage
           className="wordmark"
           src={source || './icon.png'}

--- a/packages/web-shared/ui-kit/ContentCard/ContentCard.js
+++ b/packages/web-shared/ui-kit/ContentCard/ContentCard.js
@@ -39,6 +39,13 @@ function ContentCard({
       display={horizontal ? 'flex' : ''}
       onClick={onClick}
       className="content-card"
+      role="link"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          onClick(e);
+        }
+      }}
       {...props}
     >
       <Box position="relative" width={horizontal ? '50%' : ''}>


### PR DESCRIPTION
## 🐛 Issue

It's currently very difficult to get "into" the modal context when browsing web embeds. Also, none of our cards are selectable b/c they use divs. 



## ✏️ Solution

Refactoring to use `<a`s looked like an uphill slog with potentially backwards incompatible changes, so I opted to add the correct aria roles to our a/divs.  Let's not make this mistake on new-web 😅 

## 🔬 To Test

1.Open our web embeds tester
2. Poke around with voiceover on. 

1.
2.

## 📸 Screenshots

https://github.com/user-attachments/assets/2f972dad-b4fe-41c3-b2f1-7425835af237


<!--