### PR TITLE
fix: clear modal content when closing to stop videos playing

### DIFF
--- a/packages/web-shared/providers/ModalProvider.js
+++ b/packages/web-shared/providers/ModalProvider.js
@@ -38,7 +38,7 @@ const reducer = (state, action) => {
     case actionTypes.open:
       return { ...state, isOpen: true };
     case actionTypes.close:
-      return { ...state, isOpen: false };
+      return { ...state, isOpen: false, content: null };
     case actionTypes.set:
       return { ...state, content: getContentFromURL(`${action.payload}`) };
     default:


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Closes #235 

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Clear the modal's content when closing the modal to remove the video from the page and thus stop it playing.

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Run Admin, Cluster, micro-service, and web-embeds locally
2. In Admin, create or find a Feed with videos
3. Click the "Share" button and copy the embed
4. Embed the code somewhere (`web-embeds/public/index.html` is a good place)
5. Check out the embed in your browser, open a video, start the video, and then close the modal while the video is playing

The video and audio should stop playing.

## 📸 Screenshots



https://github.com/user-attachments/assets/9eab6a6a-8814-4daf-a8a0-14ceddb8d4c6

