### PR TITLE
Apo 1016 seacoast web icon background in search

### DIFF
--- a/packages/web-shared/components/Profile/Profile.js
+++ b/packages/web-shared/components/Profile/Profile.js
@@ -75,6 +75,8 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
     setImgSrc('');
   };
 
+  const { colors } = JSON.parse(currentChurch?.theme) || {};
+
   return (
     <>
       <Styled.Profile ref={ref}>
@@ -214,7 +216,10 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
                   justifyContent="center"
                   alignItems="center"
                 >
-                  <Logo source={currentChurch?.logo} />
+                  <Logo
+                    source={currentChurch?.logo}
+                    {...(colors?.iconBackground ? { backgroundColor: colors?.iconBackground } : {})}
+                  />
                 </Box>
                 <H4 mb="xxs">{rest.adTitle || 'Stay Connected'}</H4>
                 <BodyText maxWidth="285px" textAlign="center" mb="l">


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Closes #234 

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Use church's configured icon background color

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Open an embed and check the icon color
2. Open Admin, click the user icon in the bottom left, then click Organization Profile
3. Change the Brand Icon Background Color to something different than any of the existing colors
4. Refresh the embed, note the change in icon color

## 📸 Screenshots

<img width="1027" alt="Screenshot 2024-11-21 at 5 10 43 PM" src="https://github.com/user-attachments/assets/56f2ff06-c4f7-43d9-8b1f-5eb24259df15">
<img width="524" alt="Screenshot 2024-11-21 at 5 10 54 PM" src="https://github.com/user-attachments/assets/907112e8-4cd8-40b4-9998-75d4fa2d387b">
