### PR TITLE
Apo 1022 seacoast search bar alignment

### DIFF
--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { MagnifyingGlass, ArrowLeft } from '@phosphor-icons/react';
+import { themeGet } from '@styled-system/theme-get';
 
 import { systemPropTypes } from '../../ui-kit/_lib/system';
 import { Box } from '../../ui-kit';
@@ -38,6 +39,8 @@ const Searchbar = (props = {}) => {
   const textWelcome =
     firstName === '' ? <strong>Hey!&nbsp;</strong> : <strong>Hey {firstName}!&nbsp; </strong>;
 
+  const placeholderWidth = isMobile ? { width: '400px' } : { width: '225px' };
+
   const textPrompt = searchState.customPlaceholder ? (
     <Styled.TextPrompt>
       <Box
@@ -46,10 +49,7 @@ const Searchbar = (props = {}) => {
           overflow: 'hidden',
           whiteSpace: 'nowrap',
           textOverflow: 'ellipsis',
-        }}
-        width={{
-          _: '225px',
-          sm: '400px',
+          ...placeholderWidth,
         }}
       >
         {searchState.customPlaceholder}
@@ -65,10 +65,7 @@ const Searchbar = (props = {}) => {
           overflow: 'hidden',
           whiteSpace: 'nowrap',
           textOverflow: 'ellipsis',
-        }}
-        width={{
-          _: '225px',
-          sm: '400px',
+          ...placeholderWidth,
         }}
       >
         What are you looking for?

--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -36,8 +36,10 @@ const Searchbar = (props = {}) => {
   const [isMobile, setIsMobile] = useState(false);
   const [scrollPosition, setScrollPosition] = useState(0);
 
-  const textWelcome =
-    firstName === '' ? <strong>Hey!&nbsp;</strong> : <strong>Hey {firstName}!&nbsp; </strong>;
+  const textWelcome = (
+    // 0.35ch works out visually to be the width of a &nbsp;
+    <strong style={{ marginRight: '0.35ch' }}>Hey{firstName !== '' ? ` ${firstName}` : ''}!</strong>
+  );
 
   const placeholderWidth = isMobile ? { width: '400px' } : { width: '225px' };
 


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Closes #232 

The "Hey!" part of the prompt was being spaced out excessively by the `&nbsp;` for reasons I shall allow to remain unknown. Additionally, the width of the placeholder was not being calculated properly, resulting in a `width` value of `[object Object]`.

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Instead of spacing the prompts with a `&nbsp;`, use CSS to give it a right margin. Also calculate the placeholder width properly and set it via CSS.

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

I haven't been able to reproduce this locally, only was able to test by directly editing the source in the browser to remove the `&nbsp;` and use `margin-right: 0.35ch` instead.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img width="398" alt="Screenshot 2024-11-22 at 10 17 41 AM" src="https://github.com/user-attachments/assets/0842ec8c-fbd4-43a1-ac9d-818c6cc458ef"> | <img width="407" alt="Screenshot 2024-11-22 at 10 15 38 AM" src="https://github.com/user-attachments/assets/b0bf1272-5e7a-4fe3-91d4-1a233f262aed"> |

