### PR TITLE
feat: allow for specifying a custom width for the profile popup

### DIFF
--- a/packages/web-shared/components/Profile/Profile.js
+++ b/packages/web-shared/components/Profile/Profile.js
@@ -26,7 +26,7 @@ import themeGet from '@styled-system/theme-get';
 import { logout, useAuth } from '../../providers/AuthProvider';
 import authSteps from '../Auth/authSteps';
 
-const Profile = ({ theme, handleCloseProfile, ...rest }) => {
+const Profile = ({ theme, handleCloseProfile, size, ...rest }) => {
   const { currentUser } = useCurrentUser();
   const { currentChurch } = useCurrentChurch();
 
@@ -85,11 +85,13 @@ const Profile = ({ theme, handleCloseProfile, ...rest }) => {
             _: '0%',
             sm: 'xxl',
           }}
-          width={{
-            _: '100%',
-            sm: '350px',
-            md: '520px',
-          }}
+          width={
+            size ?? {
+              _: '100%',
+              sm: '350px',
+              md: '520px',
+            }
+          }
         >
           <Box display="flex" alignItems="center" justifyContent="end">
             <Styled.CloseIcon onClick={handleCloseProfile}>

--- a/packages/web-shared/components/Profile/Profile.js
+++ b/packages/web-shared/components/Profile/Profile.js
@@ -79,7 +79,7 @@ const Profile = ({ theme, handleCloseProfile, size, ...rest }) => {
 
   return (
     <>
-      <Styled.Profile ref={ref}>
+      <Styled.Profile ref={ref} {...(size ? { right: '-15px;' } : {})}>
         <Styled.ProfileCard
           borderRadius={{
             _: '0%',

--- a/packages/web-shared/components/Profile/Profile.styles.js
+++ b/packages/web-shared/components/Profile/Profile.styles.js
@@ -12,7 +12,7 @@ const Profile = withTheme(styled.div`
   position: absolute;
   transition: opacity 0.3s ease;
   z-index: 9999;
-  right: 0;
+  right: -15px;
 
   @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
     position: fixed;

--- a/packages/web-shared/components/Profile/Profile.styles.js
+++ b/packages/web-shared/components/Profile/Profile.styles.js
@@ -12,7 +12,7 @@ const Profile = withTheme(styled.div`
   position: absolute;
   transition: opacity 0.3s ease;
   z-index: 9999;
-  right: -15px;
+  right: 0;
 
   @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
     position: fixed;

--- a/packages/web-shared/components/Profile/ProfileButton.js
+++ b/packages/web-shared/components/Profile/ProfileButton.js
@@ -32,7 +32,9 @@ const ProfileButton = (props) => {
           </Box>
         )}
       </Box>
-      {showProfile ? <Profile handleCloseProfile={() => setShowProfile(false)} /> : null}
+      {showProfile ? (
+        <Profile handleCloseProfile={() => setShowProfile(false)} size={props.popupSize} />
+      ) : null}
     </Box>
   );
 };

--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -161,7 +161,7 @@ const Searchbar = (props = {}) => {
             </Styled.InterfaceWrapper>
           </Styled.Interface>
           <Box p={16}>
-            <ProfileButton />
+            <ProfileButton popupSize={searchState.searchProfileSize} />
           </Box>
         </Box>
         <SearchResults autocompleteState={autocompleteState} autocomplete={autocompleteInstance} />

--- a/packages/web-shared/embeds/Main.js
+++ b/packages/web-shared/embeds/Main.js
@@ -61,6 +61,7 @@ const Main = ({ type }) => {
                 type={widget.dataset.type}
                 church={widget.dataset.church}
                 searchFeed={widget.dataset.searchFeed}
+                searchProfileSize={widget.dataset.searchProfileSize}
                 featureFeed={widget.dataset.featureFeed}
                 modal={widget.dataset.modal}
                 emptyPlaceholderText={widget.dataset.emptyPlaceholderText}

--- a/packages/web-shared/providers/AppProvider.js
+++ b/packages/web-shared/providers/AppProvider.js
@@ -35,6 +35,7 @@ function AppProvider(props = {}) {
             <SearchProvider
               church={props.church}
               searchFeed={props.searchFeed}
+              searchProfileSize={props.searchProfileSize}
               customPlaceholder={props.customPlaceholder}
             >
               <ModalProvider>

--- a/packages/web-shared/providers/SearchProvider.js
+++ b/packages/web-shared/providers/SearchProvider.js
@@ -8,6 +8,7 @@ const SearchDispatchContext = createContext();
 const initialState = {
   church: null,
   searchFeed: null,
+  searchProfileSize: null,
   customPlaceholder: null,
   loading: true,
 };
@@ -37,6 +38,7 @@ function SearchProvider(props = {}) {
     ...initialState, // spread the original initialState object
     church: props.church, // add church to state
     searchFeed: props.searchFeed, // add search feed id to state
+    searchProfileSize: props.searchProfileSize, // specify a custom width for the profile popup
     customPlaceholder: props.customPlaceholder, // add search custom placeholder to state
   });
 

--- a/web-embeds/README.md
+++ b/web-embeds/README.md
@@ -54,6 +54,13 @@ For the 'FeatureFeed' embed, which displays the church's content, add `data-type
 
 _⚠️ Make sure to replace [INSERT_CHURCH_SLUG_HERE] with your church's unique identifier, or 'slug'._
 
+## Search type: Custom Profile modal width:
+For the Search embed type, to control the width of the Profile modal that appears when click the "Profile" button, use the `data-search-profile-size` attribute.
+
+```
+<div class="apollos-widget" data-type="Search" data-church="bayside" data-search-profile-size="365px"></div>
+```
+
 ### Enabling Caching for Local Frustration
 
 For local development and testing purposes, you might want to enable caching to ensure you're not receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:
@@ -72,6 +79,7 @@ In this file, locate the header configuration within the `apollosApiLink` functi
 | ----------- |
 | Auth        |
 | FeatureFeed |
+| Search      |
 
 | data-church                |
 | -------------------------- |

--- a/web-embeds/src/App.js
+++ b/web-embeds/src/App.js
@@ -24,6 +24,9 @@ function App() {
   const searchFeed = searchElement
     ? searchElement.getAttribute("data-search-feed")
     : null;
+  const searchProfileSize = searchElement
+    ? searchElement.getAttribute("data-search-profile-size")
+    : null;
   const church = churchElement
     ? churchElement.getAttribute("data-church")
     : null;
@@ -57,6 +60,7 @@ function App() {
     <AppProvider
       church={church}
       searchFeed={searchFeed}
+      searchProfileSize={searchProfileSize}
       customPlaceholder={customPlaceholder}
       usePathRouter={usePathRouter}
     >


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Closes #233 

The profile popup width is based on the viewport width by default, and is absolutely positioned so its width isn't controlled by its container.

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Implement a new data prop `data-search-profile-size` which takes a CSS width string, allowing the consumer to specify whatever width they need.

Also nudge the popup to the right 15px to align it with the search bar.

## 🔬 To Test

I haven't been able to reproduce this locally, only was able to test by directly editing the source in the browser to apply the styling changes. 

## 📸 Screenshots

With `data-search-profile-size` set to `365px`:
<img width="477" alt="Screenshot 2024-11-25 at 9 57 37 AM" src="https://github.com/user-attachments/assets/03cff96d-9cf5-4ae4-b807-3e2e2c8e92fb">


<!--
| Before | After |
| --- | --- |
| _attach image_ | _attach image_ |
| _attach image_ | _attach image_ |
-->
