### PR TITLE
feat: add a classname for apollos-modal

### DIFF
--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -70,7 +70,7 @@ const Modal = (props = {}) => {
 
   return (
     <Box>
-      <Styled.Modal show={state.isOpen}>
+      <Styled.Modal className="apollos-modal" show={state.isOpen}>
         {state.content ? (
           <>
             <Styled.ModalContainer ref={ref} role="dialog" tabIndex={-1} aria-dialog={true}>

--- a/web-embeds/public/index.html
+++ b/web-embeds/public/index.html
@@ -53,9 +53,17 @@
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
 
-  <div data-type="FeatureFeed" data-church="liquid_church"
+  <!-- <div data-type="FeatureFeed" data-church="liquid_church"
     data-feature-feed="FeatureFeed:04160599-4edf-4824-98c5-02c1a8854c48" data-placeholder="What are you looking for?"
-    data-modal="true" data-use-path-router="true" class="apollos-widget"></div>
+    data-modal="true" data-use-path-router="true" class="apollos-widget"></div> -->
+
+    <div
+      data-type="FeatureFeed"
+      data-church="apollos_demo"
+      data-feature-feed="FeatureFeed:caf294f0-cd0e-4486-95e7-fa11bd5fb1c5"
+      data-modal="true"
+      class="apollos-widget"
+    ></div>
 
   <div data-type="FeatureFeed" data-church="liquid_church"
     data-feature-feed="FeatureFeed:7ff30e63-caa8-4015-bc00-73633e857b2f" data-modal="true" class="apollos-widget"

--- a/web-embeds/public/index.html
+++ b/web-embeds/public/index.html
@@ -53,10 +53,6 @@
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
 
-  <!-- <div data-type="FeatureFeed" data-church="liquid_church"
-    data-feature-feed="FeatureFeed:04160599-4edf-4824-98c5-02c1a8854c48" data-placeholder="What are you looking for?"
-    data-modal="true" data-use-path-router="true" class="apollos-widget"></div> -->
-
     <div
       data-type="FeatureFeed"
       data-church="apollos_demo"


### PR DESCRIPTION
## 🐛 Issue
Fix APO-1089

## ✏️ Solution

Added a class name to the Modal component for better CSS targeting

## 🔬 To Test

1. Open the web-embeds demo page
2. Verify the modal has the class name "apollos-modal"

## 📸 Screenshots

![Screenshot 2024-12-03 at 10.05.33 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cC1wbzju6tRNdXbxLHUd/6da55b91-428c-4751-a896-ee18c678082d.png)

