### PR TITLE
fix: use apollosId in the search params instead of generic id

### DIFF
--- a/packages/web-shared/components/Modal/Modal.js
+++ b/packages/web-shared/components/Modal/Modal.js
@@ -26,14 +26,9 @@ function ChurchLogo(props) {
 
 const Modal = (props = {}) => {
   const [state, dispatch] = useModal();
-
-  console.log('Modal props: ', props);
-
   const ref = useRef();
   const imageRef = useRef();
   const { id, navigate } = useNavigation();
-
-  console.log('Navigation ID: ', id);
 
   useEffect(() => {
     // Watch for changes to the `id` search param

--- a/packages/web-shared/providers/NavigationProvider.js
+++ b/packages/web-shared/providers/NavigationProvider.js
@@ -6,11 +6,11 @@ const NavigationContext = createContext({ id: null, navigate: () => {} });
 
 const NavigationProvider = (props = {}) => {
   const [searchParams] = useSearchParams();
-  const { contentId, feedId } = useParams();
+  const { apollosId, contentId, feedId } = useParams();
   const shouldUsePathRouter = useShouldUsePathRouter();
   const nativeNavigate = useNavigate();
 
-  const id = contentId || feedId || searchParams.get('id');
+  const id = contentId || feedId || apollosId || searchParams.get('apollosId');
   let navigate = () => {};
 
   if (shouldUsePathRouter) {
@@ -31,7 +31,7 @@ const NavigationProvider = (props = {}) => {
     navigate = ({ id, type } = {}) => {
       if (id) {
         nativeNavigate({
-          search: `?id=${id}`,
+          search: `?apollosId=${id}`,
         });
       } else {
         nativeNavigate({


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Slack convo: https://differential.slack.com/archives/C03BRNGDCPK/p1733237201495279

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->
Use `apollosId` in the Search Params instead of the generic `id` to avoid conflicts with other embeds (like Ministry Platform)

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. Confirm working locally
2. Deploy,
1. Go to https://seacoast-church.webflow.io/form?id=0dc432be-30ef-4019-adbb-61dcfcad044c, search for the element with a class of `apollos-modal`
1. May need to hard refresh, and clear cache to get latest embed
1. Make sure that modal is not open and blocking interaction with the form on the page

## 📸 Screenshots

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/cC1wbzju6tRNdXbxLHUd/556ebe1a-e561-477c-a92c-93648aa57dc6.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/cC1wbzju6tRNdXbxLHUd/556ebe1a-e561-477c-a92c-93648aa57dc6.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cC1wbzju6tRNdXbxLHUd/556ebe1a-e561-477c-a92c-93648aa57dc6.mp4">Arc.mp4</video>

