### PR TITLE
feat: add base margin to search feed

### DIFF
--- a/packages/web-shared/components/Searchbar/SearchResults.js
+++ b/packages/web-shared/components/Searchbar/SearchResults.js
@@ -324,7 +324,7 @@ const SearchResults = ({ autocompleteState, autocomplete }) => {
         ) : null
       }
       {autocompleteState.isOpen && autocompleteState.query === '' && searchState.searchFeed ? (
-        <Box className="empty-feed">
+        <Box className="empty-feed" margin="base">
           <FeatureFeedProvider
             Component={Feed}
             options={{

--- a/web-embeds/public/index.html
+++ b/web-embeds/public/index.html
@@ -51,6 +51,14 @@
       class="apollos-widget"
       style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
     ></div> -->
+    <div
+      data-church="apollos_demo"
+      data-type="Auth"
+      data-modal="true"
+      class="apollos-widget"
+      style="max-width: 1180px; padding: 40px; margin: auto; margin-top: 20px"
+      data-search-feed="FeatureFeed:caf294f0-cd0e-4486-95e7-fa11bd5fb1c5"
+    ></div>
 
     <div
       data-type="FeatureFeed"


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Github or Basecamp this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->

Search Feed needs margin

## ✏️ Solution

<!--
Describe your changes, and why you're making them. If there's something novel or complex about your approach, you can call it out here. 
-->

Add margin to Search Feed

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1. `cd web-embds`
2. `yarn dev`
1. Have Cluster running locally
1. Open the Search Embed
1. See margin around the feed

## 📸 Screenshots

Before | After
---|---
![before.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cC1wbzju6tRNdXbxLHUd/bd041483-09b5-43e9-be58-7597b6f592a8.png) | ![after.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cC1wbzju6tRNdXbxLHUd/5830d0d3-0fb9-4388-ad27-0c8b8af1796c.png)

