### PR TITLE
fixed jump when clicking search

### DIFF
--- a/packages/web-shared/components/Searchbar/Searchbar.js
+++ b/packages/web-shared/components/Searchbar/Searchbar.js
@@ -104,9 +104,6 @@ const Searchbar = (props = {}) => {
     } else {
       // Restore body to normal position
       document.body.style.position = '';
-
-      // Restore the scroll position
-      window.scrollTo(0, scrollPosition);
     }
 
     // Clean up the effect when the component unmounts


### PR DESCRIPTION
## 🐛 Issue
Closes APO-1159
Closes #247 
Closes #248 

## ✏️ Solution

Removed unnecessary scroll position restoration in the Searchbar component when closing the search overlay. This prevents unwanted scrolling behavior when the search interface is interacted with.

## 🔬 To Test
1. Click on a Search Embed
1. Type in the Search Embed
1. Verify that the page maintains its current scroll position without jumping

## 📸 Screenshots

### Before
<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/cC1wbzju6tRNdXbxLHUd/ff53aa53-4616-4017-8bad-c7250a33dc14.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/cC1wbzju6tRNdXbxLHUd/ff53aa53-4616-4017-8bad-c7250a33dc14.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cC1wbzju6tRNdXbxLHUd/ff53aa53-4616-4017-8bad-c7250a33dc14.mp4">before.mp4</video>

### After
<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/cC1wbzju6tRNdXbxLHUd/c635c3c8-b365-4ee9-9aea-7b46972175e2.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/cC1wbzju6tRNdXbxLHUd/c635c3c8-b365-4ee9-9aea-7b46972175e2.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cC1wbzju6tRNdXbxLHUd/c635c3c8-b365-4ee9-9aea-7b46972175e2.mp4">after.mp4</video>

