### PR TITLE
expose embeds version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,11 @@ jobs:
         working-directory: web-embeds
 
       - name: Deploy to NPM
-        run: yarn bump
+        run: |
+          ./scripts/bump.sh
+          yarn build
+          npm publish
+          ./flush-cdn-cache.sh
         working-directory: web-embeds
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/web-embeds/package.json
+++ b/web-embeds/package.json
@@ -60,12 +60,8 @@
     "dev": "craco start",
     "build": "node scripts/build.js",
     "test": "craco test",
-    "bump": "yarn build && ./scripts/bump.sh && npm publish && npm version 0.0.1 && npm run flush-cdn",
-    "bump:minor": "yarn build && ./scripts/bump.sh minor && npm publish && npm version 0.0.1 && npm run flush-cdn",
-    "bump:major": "yarn build && ./scripts/bump.sh major && npm publish && npm version 0.0.1 && npm run flush-cdn",
     "format": "prettier --write .",
-    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
-    "flush-cdn": "./flush-cdn-cache.sh"
+    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint ."
   },
   "eslintConfig": {
     "extends": [

--- a/web-embeds/src/index.js
+++ b/web-embeds/src/index.js
@@ -15,7 +15,7 @@ window.document.body.insertAdjacentHTML(
   '<div id="apollos-project-widget"></div>'
 );
 
-window.apollosEmbedVersion = packageJson.version;
+window.apollosEmbedsVersion = packageJson.version;
 
 const root = ReactDOM.createRoot(
   document.getElementById("apollos-project-widget")

--- a/web-embeds/src/index.js
+++ b/web-embeds/src/index.js
@@ -8,11 +8,14 @@ import ReactDOM from "react-dom/client";
 
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import packageJson from "../package.json";
 
 window.document.body.insertAdjacentHTML(
   "afterbegin",
   '<div id="apollos-project-widget"></div>'
 );
+
+window.apollosEmbedVersion = packageJson.version;
 
 const root = ReactDOM.createRoot(
   document.getElementById("apollos-project-widget")


### PR DESCRIPTION
We need to know the embeds version a website is using for debug purposes

<img width="1582" alt="Screenshot 2024-12-30 at 5 37 40 PM" src="https://github.com/user-attachments/assets/619ac4f4-2b1d-4082-8b03-a7e935935598" />
