### PR TITLE
stop making currentuser requests not logged in

### DIFF
--- a/packages/web-shared/analytics/amplitude.js
+++ b/packages/web-shared/analytics/amplitude.js
@@ -4,7 +4,7 @@ export const trackEvent = (eventName, properties = null) => {
   amplitudeJS.getInstance().logEvent(eventName, properties);
 };
 
-export const init = (amplitudeKey, currentUser = false) => {
+export const init = (amplitudeKey, currentUser = null) => {
   const ampInstance = amplitudeJS.getInstance();
   if (amplitudeKey) {
     ampInstance.init(amplitudeKey);

--- a/packages/web-shared/providers/AnalyticsProvider.js
+++ b/packages/web-shared/providers/AnalyticsProvider.js
@@ -3,12 +3,15 @@ import { gql, useQuery } from '@apollo/client';
 import { useCurrentChurch, useCurrentUser } from '../hooks';
 import amplitude from '../analytics/amplitude';
 import clientFactory from '../analytics/segment';
+import { useAuth } from './AuthProvider';
 import { isbot } from 'isbot';
 
 const Context = createContext();
+const isBot = isbot(navigator.userAgent);
+const isDev = process.env.NODE_ENV !== 'production';
 
 export const GET_ANALYTICS_USER = gql`
-  query GetAnalyticsUser {
+  query GetWebAnalyticsUser {
     currentUser {
       id
       originId
@@ -29,6 +32,15 @@ export const GET_ANALYTICS_USER = gql`
           uri
         }
       }
+    }
+  }
+`;
+
+export const GET_CHURCH_ANALYTICS = gql`
+  query {
+    currentChurch {
+      webAmplitudeKey
+      webSegmentKey
     }
   }
 `;
@@ -54,28 +66,26 @@ export const GET_ANALYTICS_USER = gql`
  * @param {church} church The church slug to pass to the analytics client's group function.
  */
 export const AnalyticsProvider = ({ children, church }) => {
-  const { currentChurch } = useCurrentChurch();
-  const { currentUser } = useCurrentUser();
-  const isBot = isbot(navigator.userAgent);
-
-  const segmentClients = [
-    clientFactory('YxKgDjmwjTQrTdm6mO34kArQIYFmfnAY', true),
-    clientFactory(currentChurch?.webSegmentKey, true),
-  ].filter(Boolean);
-
+  const [authState] = useAuth();
+  const { data: churchData } = useQuery(GET_CHURCH_ANALYTICS);
+  const { currentUser } = useCurrentUser({ skip: !authState.authenticated });
   const clients = useMemo(() => {
-    if (isBot) {
+    if (isBot || isDev) {
       return [];
     }
+    amplitude.init(churchData?.currentChurch?.webAmplitudeKey, currentUser);
+    const segmentClients = [
+      clientFactory('YxKgDjmwjTQrTdm6mO34kArQIYFmfnAY', true),
+      clientFactory(churchData?.currentChurch?.webSegmentKey, true),
+    ].filter(Boolean);
     return [{ track: amplitude.trackEvent, identify: amplitude.init }, ...segmentClients];
-  }, [isBot, segmentClients]);
-
-  amplitude.init(currentChurch?.webAmplitudeKey, currentUser);
+  }, [isBot, churchData, currentUser]);
 
   // Auto track user
   const { data } = useQuery(GET_ANALYTICS_USER, {
     returnPartialData: true,
     errorPolicy: 'ignore',
+    skip: !authState.authenticated,
   });
 
   const client = useMemo(() => {

--- a/packages/web-shared/providers/AnalyticsProvider.js
+++ b/packages/web-shared/providers/AnalyticsProvider.js
@@ -7,7 +7,6 @@ import { useAuth } from './AuthProvider';
 import { isbot } from 'isbot';
 
 const Context = createContext();
-const isBot = isbot(navigator.userAgent);
 const isDev = process.env.NODE_ENV !== 'production';
 
 export const GET_ANALYTICS_USER = gql`
@@ -69,6 +68,7 @@ export const AnalyticsProvider = ({ children, church }) => {
   const [authState] = useAuth();
   const { data: churchData } = useQuery(GET_CHURCH_ANALYTICS);
   const { currentUser } = useCurrentUser({ skip: !authState.authenticated });
+  const isBot = isbot(navigator.userAgent);
   const clients = useMemo(() => {
     if (isBot || isDev) {
       return [];


### PR DESCRIPTION
This pull request includes several changes to improve the analytics tracking and querying functionality in the `packages/web-shared` module. The most important changes include updating the initialization of analytics, adding new GraphQL queries, and modifying the `AnalyticsProvider` component to better handle authentication and environment checks.

### Analytics Initialization and Tracking:

* [`packages/web-shared/analytics/amplitude.js`](diffhunk://#diff-82b1998460a9d1fb52e9f9a68da1511626b7e9e76186aa461e65197d126739b9L7-R7): Changed the `init` function to accept `currentUser` as `null` instead of `false` for better consistency.

### GraphQL Queries:

* [`packages/web-shared/providers/AnalyticsProvider.js`](diffhunk://#diff-6d497aa7d5306b74a0d62e5c725a70527ae7625ccf180190abd216af9ca83bdeR6-R14): Renamed the `GET_ANALYTICS_USER` query to `GET_WEB_ANALYTICS_USER` for clarity.
* [`packages/web-shared/providers/AnalyticsProvider.js`](diffhunk://#diff-6d497aa7d5306b74a0d62e5c725a70527ae7625ccf180190abd216af9ca83bdeR39-R47): Added a new GraphQL query `GET_CHURCH_ANALYTICS` to fetch analytics keys for the current church.

### AnalyticsProvider Component:

* [`packages/web-shared/providers/AnalyticsProvider.js`](diffhunk://#diff-6d497aa7d5306b74a0d62e5c725a70527ae7625ccf180190abd216af9ca83bdeL57-R88): Updated the `AnalyticsProvider` component to use the new `GET_CHURCH_ANALYTICS` query and handle authentication state using the `useAuth` hook.
* [`packages/web-shared/providers/AnalyticsProvider.js`](diffhunk://#diff-6d497aa7d5306b74a0d62e5c725a70527ae7625ccf180190abd216af9ca83bdeL57-R88): Added checks for `isBot` and `isDev` to conditionally initialize analytics clients, ensuring analytics are not tracked in development or by bots.

https://differential-ka.sentry.io/issues/6318414409/?project=6599411&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0

**Proof that it runs after logging in**

<img width="1795" alt="Screenshot 2025-02-26 at 5 53 34 PM" src="https://github.com/user-attachments/assets/5c17b658-1d12-4d66-ad83-7db1cf828323" />

