### PR TITLE
fix youtube links

### DIFF
--- a/packages/web-shared/components/VideoPlayer/VideoPlayer.js
+++ b/packages/web-shared/components/VideoPlayer/VideoPlayer.js
@@ -39,7 +39,7 @@ function VideoPlayer(props = {}) {
     (video) => video.sources?.length && video.sources[0].uri?.includes('.m3u8')
   );
   const youtubeMedia = props.parentNode?.videos?.find(
-    (video) => video.sources?.length && video.sources[0].uri?.includes('youtube.com')
+    (video) => video.sources?.length && video.sources[0].uri?.includes('youtu')
   );
   const videoMedia = youtubeMedia || hlsMedia;
 


### PR DESCRIPTION
This pull request includes a small change to the `VideoPlayer` component in the `packages/web-shared` directory. The change modifies the condition for identifying YouTube videos by checking for a broader match in the URI.

* [`packages/web-shared/components/VideoPlayer/VideoPlayer.js`](diffhunk://#diff-d7412c3d7876a3cea451786f746381e19896808e8cc5345893602b6dab8928a0L42-R42): Updated the condition to identify YouTube videos by checking if the URI includes 'youtu' instead of 'youtube.com'.

<img width="1582" alt="Screenshot 2025-03-03 at 9 02 32 AM" src="https://github.com/user-attachments/assets/a0ccda33-5637-4719-afb0-85a4ba79ed75" />
