### PR TITLE
refactor: always pass config to videoplayer

### DIFF
--- a/packages/web-shared/components/VideoPlayer/VideoPlayer.js
+++ b/packages/web-shared/components/VideoPlayer/VideoPlayer.js
@@ -244,13 +244,6 @@ function VideoPlayer(props = {}) {
     ? props.parentNode?.stream?.sources[0]?.uri
     : videoMedia?.sources[0]?.uri;
 
-  const config = useMemo(() => {
-    if (source?.includes('youtube.com')) {
-      return undefined;
-    }
-    return { file: { hlsVersion: '1.5.19' } };
-  }, [source]);
-
   if (props.parentNode?.videos?.embedHtml) {
     return (
       <EmbededPlayer
@@ -271,7 +264,7 @@ function VideoPlayer(props = {}) {
         <Player
           ref={playerRef}
           controls={true}
-          config={config}
+          config={{ file: { hlsVersion: '1.5.19' } }}
           onEnded={handleVideoEnded}
           onError={handleVideoError}
           onReady={handleVideoLoad}


### PR DESCRIPTION
This configuration is harmless for youtube videos as can be seen on seacoast where youtube links are youtu.be and are bypassing this logic
