### PR TITLE
Handle multi day event start end time

### DIFF
--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -37,6 +37,12 @@ const infoDivider = (
   </BodyText>
 );
 
+const timeDivider = (
+  <BodyText color="text.tertiary" mx="xs" display={{ xs: 'none', sm: 'block' }}>
+    -
+  </BodyText>
+);
+
 const CalendarIconWrapper = styled.span`
   margin-right: ${({ theme }) => theme.space.xxs};
   display: inline-flex;
@@ -56,7 +62,26 @@ const FlexBodyText = styled(BodyText)`
   align-items: center;
 `;
 
-function CalendarData({ start, end, location }) {
+function CalendarData({ start, end, startTime, endTime, location }) {
+  const [formatEndDateTime, setFormatEndDateTime] = useState(null);
+  const [formatStartDateTime, setFormatStartDateTime] = useState(null);
+
+  useEffect(() => {
+    if (start === end) {
+      setFormatEndDateTime(endTime);
+    } else {
+      setFormatEndDateTime(end + ' | ' + endTime);
+    }
+  }, [start, end, endTime]);
+
+  useEffect(() => {
+    if (startTime) {
+      setFormatStartDateTime(start + ' | ' + startTime);
+    } else {
+      setFormatEndDateTime(start);
+    }
+  }, [start, startTime]);
+
   return (
     <>
       {location ? (
@@ -66,17 +91,17 @@ function CalendarData({ start, end, location }) {
         </FlexBodyText>
       ) : null}
       {start && location ? infoDivider : null}
-      {start ? (
+      {formatStartDateTime ? (
         <FlexBodyText color="text.secondary" mb={'xxs'}>
           <CalendarIcon name="calendar" />
-          {start}
+          {formatStartDateTime}
         </FlexBodyText>
       ) : null}
-      {end && start ? infoDivider : null}
-      {end ? (
+      {formatStartDateTime && formatEndDateTime ? timeDivider : null}
+      {formatEndDateTime ? (
         <FlexBodyText color="text.secondary" mb={'xxs'}>
           <CalendarIcon name="clock" />
-          {end}
+          {formatEndDateTime}
         </FlexBodyText>
       ) : null}
     </>
@@ -184,13 +209,14 @@ function ContentSingle(props = {}) {
   const formattedStartDate = props?.data?.start
     ? format(parseISO(props.data.start), 'eee, MMMM do, yyyy')
     : null;
-  const formattedStartToEnd =
-    props?.data?.start && props?.data?.end
-      ? `${format(parseISO(props.data.start), 'hh:mm a')} — ${format(
-          parseISO(props.data.end),
-          'hh:mm a'
-        )}`
-      : null;
+  const formattedStartTime = props?.data?.start
+    ? format(parseISO(props.data.start), 'hh:mm a')
+    : null;
+  const formattedEndDate = props?.data?.end
+    ? format(parseISO(props.data.end), 'eee, MMMM do, yyyy')
+    : null;
+  const formattedEndTime = props?.data?.end ? format(parseISO(props.data.end), 'hh:mm a') : null;
+
   const handleActionPress = (item) => {
     if (idFromParams !== getURLFromType(item)) {
       navigate({
@@ -283,7 +309,9 @@ function ContentSingle(props = {}) {
 
                 <CalendarData
                   start={formattedStartDate}
-                  end={formattedStartToEnd}
+                  end={formattedEndDate}
+                  startTime={formattedStartTime}
+                  endTime={formattedEndTime}
                   location={props?.data?.location}
                 />
               </Box>

--- a/packages/web-shared/components/ContentSingle.js
+++ b/packages/web-shared/components/ContentSingle.js
@@ -90,19 +90,23 @@ function CalendarData({ start, end, startTime, endTime, location }) {
           {location}
         </FlexBodyText>
       ) : null}
-      {start && location ? infoDivider : null}
-      {formatStartDateTime ? (
-        <FlexBodyText color="text.secondary" mb={'xxs'}>
-          <CalendarIcon name="calendar" />
-          {formatStartDateTime}
-        </FlexBodyText>
-      ) : null}
-      {formatStartDateTime && formatEndDateTime ? timeDivider : null}
-      {formatEndDateTime ? (
-        <FlexBodyText color="text.secondary" mb={'xxs'}>
-          <CalendarIcon name="clock" />
-          {formatEndDateTime}
-        </FlexBodyText>
+      {(formatStartDateTime || formatEndDateTime) && location ? infoDivider : null}
+      {formatStartDateTime || formatEndDateTime ? (
+        <Box display="flex" flexDirection={'row'} alignItems="flex-start" width="100%">
+          {formatStartDateTime ? (
+            <FlexBodyText color="text.secondary" mb={'xxs'}>
+              <CalendarIcon name="calendar" />
+              {formatStartDateTime}
+            </FlexBodyText>
+          ) : null}
+          {formatStartDateTime && formatEndDateTime ? timeDivider : null}
+          {formatEndDateTime ? (
+            <FlexBodyText color="text.secondary" mb={'xxs'}>
+              <CalendarIcon name="clock" />
+              {formatEndDateTime}
+            </FlexBodyText>
+          ) : null}
+        </Box>
       ) : null}
     </>
   );


### PR DESCRIPTION
## 🐛 Issue

<!-- Link to the issue in Linear this PR is addressing. If there is no related issue or related pull request, consider briefly describing the problem or enhancement being addressed. -->
Closes [APO-6349: (Echo) Multi‑day event shows incorrect date range on Event page](https://linear.app/differential/issue/APO-6349/echo-multi‑day-event-shows-incorrect-date-range-on-event-page)

## ✏️ Solution

Handle multi day event start end time

## 🔬 To Test

<!--
With only the context in this description, how would a developer from outside Apollos setup and validate your change? 
-->

1.
2.

## 📸 Screenshots

<img width="673" height="662" alt="Screenshot 2026-01-14 at 14 51 34" src="https://github.com/user-attachments/assets/86b0d3b6-319b-4d59-aae3-3fa5b68e6732" />
<img width="689" height="646" alt="Screenshot 2026-01-14 at 14 51 55" src="https://github.com/user-attachments/assets/234f0295-74ab-409b-928e-36a10c7a1f10" />
<img width="659" height="610" alt="Screenshot 2026-01-14 at 14 52 04" src="https://github.com/user-attachments/assets/6ad31471-10fc-4e41-9c3b-953dca322839" />
<img width="665" height="657" alt="Screenshot 2026-01-14 at 14 50 57" src="https://github.com/user-attachments/assets/941c97ed-dfce-410a-95c9-181bed43936f" />


