### PR TITLE
SYM-22: Support MP3 audio in legacy web embeds

### DIFF
--- a/packages/web-shared/components/VideoPlayer/VideoPlayer.js
+++ b/packages/web-shared/components/VideoPlayer/VideoPlayer.js
@@ -35,14 +35,17 @@ function VideoPlayer(props = {}) {
   const [progressTime, setProgressTime] = useState(0);
   const [paused, setPaused] = useState(false);
 
+  const hasSource = (video) => video.sources?.some((source) => source?.uri);
+
   // will find the first HLS video playlist provided
-  const hlsMedia = props.parentNode?.videos?.find(
-    (video) => video.sources?.length && video.sources[0].uri?.includes('.m3u8')
+  const hlsMedia = props.parentNode?.videos?.find((video) =>
+    video.sources?.some((source) => source?.uri?.includes('.m3u8'))
   );
-  const youtubeMedia = props.parentNode?.videos?.find(
-    (video) => video.sources?.length && video.sources[0].uri?.includes('youtu')
+  const youtubeMedia = props.parentNode?.videos?.find((video) =>
+    video.sources?.some((source) => source?.uri?.includes('youtu'))
   );
-  const videoMedia = youtubeMedia || hlsMedia;
+  const fallbackMedia = props.parentNode?.videos?.find(hasSource);
+  const videoMedia = youtubeMedia || hlsMedia || fallbackMedia;
 
   const userProgress = props.userProgress || { playhead: 0, complete: false };
 
@@ -243,8 +246,8 @@ function VideoPlayer(props = {}) {
   };
 
   const source = isLiveStreaming
-    ? props.parentNode?.stream?.sources[0]?.uri
-    : videoMedia?.sources[0]?.uri;
+    ? props.parentNode?.stream?.sources?.find((streamSource) => streamSource?.uri)?.uri
+    : videoMedia?.sources?.find((videoSource) => videoSource?.uri)?.uri;
 
   if (props.parentNode?.videos?.embedHtml) {
     return (

--- a/web-embeds/src/VideoPlayer.test.js
+++ b/web-embeds/src/VideoPlayer.test.js
@@ -1,0 +1,66 @@
+import React from "react";
+
+import { render, screen } from "@testing-library/react";
+
+import VideoPlayer from "../../packages/web-shared/components/VideoPlayer/VideoPlayer";
+
+jest.mock(
+  "../../packages/web-shared/components/VideoPlayer/VideoPlayer.styles",
+  () => ({
+    ...(() => {
+      const React = require("react");
+
+      return {
+        EmbededPlayer: ({ children }) => <div>{children}</div>,
+        VideoPlayer: React.forwardRef(({ children, url }, ref) => (
+          <div data-testid="player-shell" data-url={url} ref={ref}>
+            {children}
+          </div>
+        )),
+      };
+    })(),
+  })
+);
+
+jest.mock("../../packages/web-shared/hooks", () => ({
+  useHTMLContent: () => (html) => html,
+  useInteractWithNode: () => [jest.fn()],
+  useLivestreamStatus: () => ({ status: "isNotLive" }),
+}));
+
+jest.mock("../../packages/web-shared/providers/AnalyticsProvider", () => ({
+  useAnalytics: () => ({
+    track: jest.fn(),
+  }),
+}));
+
+jest.mock("../../packages/web-shared/ui-kit", () => ({
+  Box: ({ children }) => <div>{children}</div>,
+}));
+
+describe("VideoPlayer", () => {
+  it("renders an MP3 source for legacy embeds", () => {
+    render(
+      <VideoPlayer
+        coverImage="https://example.com/cover.jpg"
+        parentNode={{
+          id: "content-1",
+          publishDate: "0",
+          title: "Audio content",
+          videos: [
+            {
+              id: "video-1",
+              sources: [{ uri: "https://example.com/audio.mp3" }],
+            },
+          ],
+        }}
+        userProgress={{ complete: false, playhead: 0 }}
+      />
+    );
+
+    expect(screen.getByTestId("player-shell")).toHaveAttribute(
+      "data-url",
+      "https://example.com/audio.mp3"
+    );
+  });
+});


### PR DESCRIPTION
## 🐛 Issue

Closes SYM-22
Closes APO-7576
Closes APO-7468

## ✏️ Solution

Legacy embed playback only selected YouTube or HLS video sources, so content items with only an MP3 source rendered no player at all.

This change keeps the existing YouTube/HLS priority but falls back to the first available media source when those formats are absent. That allows MP3-backed legacy embeds to render through the existing player path without changing the current preferred-source behavior.

## 🔬 To Test

1. Run `cd packages/web-shared && npx -y yarn@1.22.22 lint`.
2. Run `cd web-embeds && npx -y yarn@1.22.22 lint`.
3. Run `cd web-embeds && CI=1 npx -y yarn@1.22.22 test --watch=false --runInBand --testPathPattern=VideoPlayer.test.js` and confirm the MP3-only `VideoPlayer` test passes.
4. Run `cd web-embeds && npx -y yarn@1.22.22 build`.
5. Run `cd micro-service && npx -y yarn@1.22.22 build`.
6. Open a legacy embed page backed by a content item whose only media source is an MP3 URL and confirm the player renders instead of showing only the cover image / empty media area.

## 📸 Screenshots

<img width="1440" height="1800" alt="seacoast-pr266-validation" src="https://github.com/user-attachments/assets/73ef8204-abb4-4889-808b-0c466d3f2b37" />

