### PR TITLE
fix: prevent image stretching when explicit width/height attributes are present

### DIFF
--- a/packages/web-shared/ui-kit/Longform/Longform.styles.js
+++ b/packages/web-shared/ui-kit/Longform/Longform.styles.js
@@ -38,6 +38,10 @@ const Longform = styled.div`
     margin-bottom: ${themeGet('space.base')};
   }
 
+  img {
+    height: auto;
+  }
+
   > ul,
   > ol {
     margin-left: ${themeGet('space.base')} !important;

--- a/web-embeds/src/index.css
+++ b/web-embeds/src/index.css
@@ -44,7 +44,6 @@
 .apollos-widget img {
   display: block;
   max-width: 100%;
-  height: auto;
 }
 
 .apollos-widget a {

--- a/web-embeds/src/index.css
+++ b/web-embeds/src/index.css
@@ -44,6 +44,7 @@
 .apollos-widget img {
   display: block;
   max-width: 100%;
+  height: auto;
 }
 
 .apollos-widget a {


### PR DESCRIPTION
## Summary

- Scoped rich-content images to `height: auto` inside `Longform` so HTML images saved with explicit `width`/`height` attributes scale proportionally in web embeds.
- Kept the global `.apollos-widget img` rule unchanged so widget UI images continue to use their component-defined sizing.

## Root Cause

The affected The Hills content item renders an HTML image with `width="1920" height="1080"`. The embed already constrained image width to the `700px` content column, but the HTML height attribute stayed at `1080px`, stretching the image vertically. `ContentSingle` and `HtmlFeature` render this HTML through `Longform`, so the fix belongs on rich content images rather than every widget image.

## Validation

- [x] `yarn workspace @apollosproject/apollos-embeds lint`
- [x] `yarn workspace @apollosproject/web-shared lint` (existing warnings only)
- [x] `CI=true yarn workspace @apollosproject/apollos-embeds build`
- [x] Production repro page before: affected image rendered `700 x 1080` with aspect `0.648`.
- [x] Same Webflow page with this PR's built embed bundle: affected image rendered `700 x 393.75` with aspect `1.7778`.

`web-embeds/widget` was not committed because `.github/workflows/deploy.yml` rebuilds from source with `yarn build` before `npm publish`; the local production build confirmed the generated widget output gains the scoped `img { height: auto; }` style.

## Proof

Production / current CDN bundle:

![Before: production embed stretches the 1920x1080 image to 700x1080](https://raw.githubusercontent.com/ApollosProject/apollos-embeds/88ffa07a6a398275517757e822cac42aef81ca48/proof/pr269/prod-before-stretched.png)

Same Webflow page with the PR-built embed bundle:

![After: PR bundle renders the image at the correct 16:9 aspect ratio](https://raw.githubusercontent.com/ApollosProject/apollos-embeds/88ffa07a6a398275517757e822cac42aef81ca48/proof/pr269/pr-after-fixed.png)

Closes APO-10095
