### PR TITLE
Fix legacy embed content item query

### DIFF
--- a/packages/web-shared/hooks/useContentItem.js
+++ b/packages/web-shared/hooks/useContentItem.js
@@ -60,11 +60,6 @@ export const GET_CONTENT_ITEM = gql`
           }
         }
       }
-      ... on FeaturesNode {
-        featureFeed {
-          id
-        }
-      }
       ... on ContentItem {
         title
         originId


### PR DESCRIPTION
## Summary
- Remove the obsolete `FeaturesNode` inline fragment from the legacy embed `getContentItem` query.
- Rebuild the tracked widget bundle so published `@apollosproject/apollos-embeds` no longer sends the invalid type selection.

Closes APO-10114

## Validation
- Reproduced on the public Liquid events embed: clicking `Financial Peace University` navigated back to `/` and the `getContentItem` request to `https://cdn.apollos.app/` returned 400 with `Unknown type "FeaturesNode"`.
- Verified the same event query without the `FeaturesNode` fragment returns 200 from production Cluster for `Event:048561b8-f366-465e-bf05-9f72c1abd090`.
- `yarn workspace @apollosproject/web-shared lint` passes with existing warnings only.
- `yarn workspace @apollosproject/apollos-embeds build` succeeds and rebuilds `web-embeds/widget/index.js`.
- Served the rebuilt widget locally and clicked the same event; it navigated to `/ac/Event-048561b8-f366-465e-bf05-9f72c1abd090`, rendered `Financial Peace University`, and the `getContentItem` request returned 200 with no console errors.