### PR TITLE
[codex] Migrate embeds deploy to trusted publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,16 +7,22 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Yarn Install
@@ -27,9 +33,8 @@ jobs:
         run: |
           ./scripts/bump.sh
           yarn build
-          npm publish
+          npm publish --access public
           ./flush-cdn-cache.sh
         working-directory: web-embeds
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           YARN_REGISTRY: https://registry.npmjs.org/

--- a/web-embeds/package.json
+++ b/web-embeds/package.json
@@ -3,6 +3,11 @@
   "description": "Apollos React embed widgets",
   "version": "0.0.1",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ApollosProject/apollos-embeds.git",
+    "directory": "web-embeds"
+  },
   "eslintIgnore": [
     "/node_modules",
     "/build"


### PR DESCRIPTION
## What changed

- Switch the legacy embeds deploy workflow from a long-lived `NPM_TOKEN` secret to npm trusted publishing via GitHub OIDC.
- Grant the workflow `id-token: write` and `contents: read` permissions.
- Run deploys on Node 24 through current `actions/checkout` and `actions/setup-node` releases.
- Add repository metadata to `web-embeds/package.json` so npm can associate the package with this GitHub repository.

## Why

The legacy `Deploy` workflow builds successfully, but `npm publish` fails with `E404` on the scoped package PUT. That points to an invalid or unauthorized npm token, not a build or version problem. Trusted publishing removes the rotating/stale token from this path.

## npm-side setup

Completed trusted publisher configuration for `@apollosproject/apollos-embeds`:

- Type: GitHub Actions
- Owner/repo: `ApollosProject/apollos-embeds`
- Workflow filename: `deploy.yml`
- Environment: none
- Permission: `publish`
- npm trust id: `75f16713-4fe4-4282-8055-c031e8cb0940`

Merging this PR should let the next push to `main` publish with OIDC instead of `NPM_TOKEN`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "workflow yaml ok"'`
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("web-embeds/package.json","utf8")); console.log("package json ok")'`
- Verified `actions/checkout@v6` and `actions/setup-node@v6` releases exist.
- `yarn` in `web-embeds`
- `yarn build` in `web-embeds`
- `npx -p npm@11.18.0 npm trust list @apollosproject/apollos-embeds`

Note: the local build rewrites `web-embeds/widget/index.js`; that generated artifact was intentionally not included in this PR.
