### PR TITLE
Add data-hide-trending-searches option to Search embed

### DIFF
--- a/packages/web-shared/components/Searchbar/SearchResults.js
+++ b/packages/web-shared/components/Searchbar/SearchResults.js
@@ -217,7 +217,10 @@ const SearchResults = ({ autocompleteState, autocomplete }) => {
           const { source, items } = collection;
 
           // Rendering of Query Suggestions
-          if (['querySuggestionsPlugin'].includes(collection.source.sourceId)) {
+          if (
+            ['querySuggestionsPlugin'].includes(collection.source.sourceId) &&
+            !searchState.hideTrendingSearches
+          ) {
             return (
               <div key={`source-${index}`} className="aa-Source">
                 {collection.source.sourceId === 'querySuggestionsPlugin' && !inputProps.value && (

--- a/packages/web-shared/providers/AppProvider.js
+++ b/packages/web-shared/providers/AppProvider.js
@@ -43,6 +43,7 @@ function AppProvider(props = {}) {
                 searchFeed={props.searchFeed}
                 searchProfileSize={props.searchProfileSize}
                 customPlaceholder={props.customPlaceholder}
+                hideTrendingSearches={props.hideTrendingSearches}
               >
                 <ModalProvider>
                   <ThemeProvider>{props.children}</ThemeProvider>

--- a/packages/web-shared/providers/SearchProvider.js
+++ b/packages/web-shared/providers/SearchProvider.js
@@ -11,6 +11,7 @@ const initialState = {
   searchFeed: null,
   searchProfileSize: null,
   customPlaceholder: null,
+  hideTrendingSearches: false,
   loading: true,
 };
 
@@ -41,6 +42,7 @@ function SearchProvider(props = {}) {
     searchFeed: props.searchFeed, // add search feed id to state
     searchProfileSize: props.searchProfileSize, // specify a custom width for the profile popup
     customPlaceholder: props.customPlaceholder, // add search custom placeholder to state
+    hideTrendingSearches: !!props.hideTrendingSearches, // hide the "Trending Searches" suggestions when the query is empty
   });
 
   return (

--- a/web-embeds/README.md
+++ b/web-embeds/README.md
@@ -61,6 +61,14 @@ For the Search embed type, to control the width of the Profile modal that appear
 <div class="apollos-widget" data-type="Search" data-church="bayside" data-search-profile-size="365px"></div>
 ```
 
+## Search type: Hiding Trending Searches:
+
+For the Search embed type, to hide the "Trending Searches" suggestions shown when the search box is focused with an empty query, add the `data-hide-trending-searches="true"` attribute.
+
+```
+<div class="apollos-widget" data-type="Search" data-church="bayside" data-search-feed="FeatureFeed:..." data-hide-trending-searches="true"></div>
+```
+
 ### Enabling Caching for Local Frustration
 
 For local development and testing purposes, you might want to enable caching to ensure you're not receiving the latest responses directly from the API. To do this, please refer to the Apollo client configuration file:

--- a/web-embeds/src/App.js
+++ b/web-embeds/src/App.js
@@ -49,8 +49,9 @@ function App() {
     : false;
 
   const hideTrendingSearches = hideTrendingSearchesElement
-    ? hideTrendingSearchesElement.getAttribute("data-hide-trending-searches") ===
-      "true"
+    ? hideTrendingSearchesElement.getAttribute(
+        "data-hide-trending-searches"
+      ) === "true"
     : false;
 
   const router = createBrowserRouter([

--- a/web-embeds/src/App.js
+++ b/web-embeds/src/App.js
@@ -23,6 +23,9 @@ function App() {
   const apollosIdParamElement = document.querySelector(
     "[data-apollos-id-param]"
   );
+  const hideTrendingSearchesElement = document.querySelector(
+    "[data-hide-trending-searches]"
+  );
 
   const searchFeed = searchElement
     ? searchElement.getAttribute("data-search-feed")
@@ -43,6 +46,11 @@ function App() {
 
   const useApollosIdParam = apollosIdParamElement
     ? apollosIdParamElement.getAttribute("data-apollos-id-param") === "true"
+    : false;
+
+  const hideTrendingSearches = hideTrendingSearchesElement
+    ? hideTrendingSearchesElement.getAttribute("data-hide-trending-searches") ===
+      "true"
     : false;
 
   const router = createBrowserRouter([
@@ -68,6 +76,7 @@ function App() {
       church={church}
       searchFeed={searchFeed}
       searchProfileSize={searchProfileSize}
+      hideTrendingSearches={hideTrendingSearches}
       customPlaceholder={customPlaceholder}
       usePathRouter={usePathRouter}
       useApollosIdParam={useApollosIdParam}


### PR DESCRIPTION
## 🐛 Issue

Closes APO-10499

Southside uses the Search embed as a campus-events feed on https://southside.org/events/. Focusing the empty search currently puts five global query suggestions above the relevant events, taking up most of the panel.

## ✏️ Solution

Add the opt-in `data-hide-trending-searches="true"` attribute and pass it through `AppProvider` into search state. `SearchResults` then omits only the `querySuggestionsPlugin` collection; the plugin stays registered so empty-focus panel behavior, the configured search feed, and typed results are unchanged.

The attribute is documented in the web-embeds README. When it is absent, existing Trending Searches behavior remains the default.

## 🔬 To Test

1. Add `data-hide-trending-searches="true"` to a Search widget with a `data-search-feed`.
2. Focus the empty search and confirm the feed opens without Trending Searches.
3. Type a query and confirm search results still render.
4. Remove the attribute, reload, and confirm Trending Searches returns.

## Proof

Validated at `b55bcb9` on July 21, 2026 using Southside's live `southside_church` tenant and `FeatureFeed:89ce33d6-f90f-4798-8745-2eef2588b5f8` feed. The before capture is the production events page; the after capture is this branch running locally against the same live CDN and Algolia data.

| Before — production empty focus | After — opt-out enabled |
| --- | --- |
| ![Trending Searches above Southside's events feed](https://gist.githubusercontent.com/redreceipt/4d3394876850e32127e6815ccde14cc2/raw/04fe49d5adc533bd22f7b6b2cd165004a22fc060/pr273-before.svg) | ![Southside's events feed opens without Trending Searches](https://gist.githubusercontent.com/redreceipt/4d3394876850e32127e6815ccde14cc2/raw/8b8272680dbf8021ba113bedb1bedd8c2efc58bf/pr273-after.svg) |

- Empty focus kept all eight live event cards visible and removed only the five query suggestions.
- Typing `love` returned live Algolia content results.
- Removing the attribute on the same branch restored the five suggestions, verifying the unchanged default.
